### PR TITLE
Completed initial implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,21 @@
 [package]
 name = "vl6180x"
-version = "0.1.4"
+version = "0.2.0"
 description = "A rust driver for the VL6180X (Time-of-Flight I2C laser-ranging module)"
-authors = ["Luca Zulian <lucagiuggia@gmail.com>"]
+authors = ["Luca Zulian <lucagiuggia@gmail.com>", "Shao Yuan <flossy_lineage.0b@icloud.com>"]
 categories = ["embedded", "hardware-support", "no-std"]
-keywords = ["hal", "IO"]
+keywords = ["hal", "IO",  "embedded-hal-driver", "vl6180x", "tof"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/lucazulian/vl6180x"
 edition = "2018"
-exclude = []
+exclude = [ "doc", "*.jpg", "*.png", "*.bmp" ]
 
 [dependencies]
-embedded-hal = "0.2.3"
-generic-array = "0.14.4"
-nb = "1.0.0"
+embedded-hal = {version = "0.2.7", features = ["unproven"]}
+int-enum = {version = "0.4.0", default-features = false}
 
-[dependencies.cast]
-default-features = false
-version = "0.3.0"
-uninit = "0.1.0"
+[profile.release]
+codegen-units = 1
+debug = true
+lto = true

--- a/README.md
+++ b/README.md
@@ -15,3 +15,68 @@ Include this [library](https://crates.io/crates/vl6180x) as a dependency in your
 [dependencies.vl6180x]
 version = "<version>"
 ```
+
+## Examples
+
+for more examples please see [vl6180x_stm32f401_examples](https://github.com/shaoyuancc/vl6180x_stm32f401_examples)
+
+```rust
+#![no_std]
+#![no_main]
+
+use cortex_m_rt::ExceptionFrame;
+use cortex_m_rt::{entry, exception};
+use cortex_m_semihosting::hprintln;
+use hal::{pac, prelude::*};
+use panic_semihosting as _;
+use stm32f4xx_hal as hal;
+use vl6180x;
+
+#[entry]
+fn main() -> ! {
+    if let (Some(dp), Some(_cp)) = (
+        pac::Peripherals::take(),
+        cortex_m::peripheral::Peripherals::take(),
+    ) {
+        // Set up the system clock. We want to run at 48MHz for this one.
+        let rcc = dp.RCC.constrain();
+        let clocks = rcc.cfgr.sysclk(48.MHz()).freeze();
+
+        // Set up I2C - SCL is PB8 and SDA is PB9; they are set to Alternate Function 4
+        let gpiob = dp.GPIOB.split();
+        let scl = gpiob
+            .pb8
+            .into_alternate()
+            .internal_pull_up(true)
+            .set_open_drain();
+        let sda = gpiob
+            .pb9
+            .into_alternate()
+            .internal_pull_up(true)
+            .set_open_drain();
+        let i2c = dp.I2C1.i2c((scl, sda), 400.kHz(), &clocks);
+
+        // To create sensor with default configuration:
+        let mut tof = vl6180x::VL6180X::new(i2c).expect("vl");
+
+        // This runs continuously, as fast as possible
+        loop {
+            match tof.poll_range_mm_single_blocking() {
+                Ok(range) => hprintln!("Range Single Poll: {}mm", range).unwrap(),
+                Err(e) => hprintln!("Error reading TOF sensor Single Poll! {:?}", e).unwrap(),
+            }
+        }
+    }
+
+    loop {}
+}
+
+#[exception]
+unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
+    panic!("{:#?}", ef);
+}
+```
+
+## References
+[VL6180X datasheet](https://www.st.com/resource/en/datasheet/vl6180x.pdf) (Time-of-Flight I2C laser-ranging module)
+[ST application note AN4545](https://www.st.com/resource/en/application_note/an4545-vl6180x-basic-ranging-application-note-stmicroelectronics.pdf)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,338 @@
+use super::*;
+
+#[cfg(test)]
+mod config_tests;
+
+/// Options for configuring the interrupt trigger condition for ambient measurement.
+#[derive(Debug, Clone, Copy)]
+pub enum AmbientInterruptMode {
+    /// No interrupts will be triggered
+    Disabled = 0,
+    /// Interrupt triggered when value < thresh_low
+    LevelLow = 0b00_001_000,
+    /// Interrupt triggered when value > thresh_high
+    LevelHigh = 0b00_010_000,
+    /// Interrupt triggered when value < thresh_low OR value > thresh_high
+    OutOfWindow = 0b00_011_000,
+    /// Interrupt triggered when new sample is ready (Default)
+    NewSampleReady = 0b00_100_000,
+}
+
+/// Options for configuring the interrupt trigger condition for range measurement.
+#[derive(Debug, Clone, Copy)]
+pub enum RangeInterruptMode {
+    /// No interrupts will be triggered (Default)
+    Disabled = 0,
+    /// Interrupt triggered when value < thresh_low
+    LevelLow = 0b00_000_001,
+    /// Interrupt triggered when value > thresh_high
+    LevelHigh = 0b00_000_010,
+    /// Interrupt triggered when value < thresh_low OR value > thresh_high
+    OutOfWindow = 0b00_000_011,
+    /// Interrupt triggered when new sample is ready (Default)
+    NewSampleReady = 0b00_000_100,
+}
+
+/// Config information for the driver.
+#[derive(Debug, Clone, Copy)]
+pub struct Config {
+    pub(super) ptp_offset: u8,
+
+    pub(super) address: u8,
+    pub(super) range_scaling: u8,
+    pub(super) ambient_scaling: u8,
+    pub(super) poll_max_loop: u16,
+
+    // Performance tuning
+    pub(super) readout_averaging_period_multiplier: u8,
+
+    pub(super) range_max_convergence_time: u8,
+    pub(super) range_inter_measurement_period: u16,
+    pub(super) range_vhv_recalibration_rate: u8,
+
+    pub(super) ambient_analogue_gain_level: u8,
+    pub(super) ambient_integration_period: u16,
+    pub(super) ambient_inter_measurement_period: u16,
+
+    // Interrupt modes
+    pub(super) range_interrupt_mode: RangeInterruptMode,
+    pub(super) ambient_interrupt_mode: AmbientInterruptMode,
+    pub(super) range_low_interrupt_threshold: u8,
+    pub(super) range_high_interrupt_threshold: u8,
+    pub(super) ambient_low_interrupt_threshold: u16,
+    pub(super) ambient_high_interrupt_threshold: u16,
+}
+
+impl Config {
+    /// Create new config struct with default values.
+    ///
+    /// Defaults are based on values from [ST application note AN4545](https://www.st.com/resource/en/application_note/an4545-vl6180x-basic-ranging-application-note-stmicroelectronics.pdf)
+    pub fn new() -> Self {
+        Config {
+            address: 0x29,
+            ptp_offset: 0,
+            poll_max_loop: 500,
+
+            range_scaling: 1,
+            ambient_scaling: 1,
+
+            // Performance tuning
+            readout_averaging_period_multiplier: 48,
+
+            range_max_convergence_time: 49,
+            range_inter_measurement_period: 100,
+            range_vhv_recalibration_rate: 255,
+
+            ambient_analogue_gain_level: 0,
+            ambient_integration_period: 100,
+            ambient_inter_measurement_period: 500,
+
+            // Interrupt modes
+            range_interrupt_mode: RangeInterruptMode::NewSampleReady,
+            ambient_interrupt_mode: AmbientInterruptMode::NewSampleReady,
+            range_low_interrupt_threshold: 0,
+            range_high_interrupt_threshold: 0xFF,
+            ambient_low_interrupt_threshold: 0,
+            ambient_high_interrupt_threshold: 0xFFFF,
+            // Implement in the future
+            // TODO: range_ignore
+            // TODO: ambient_lux_resolution_factor
+        }
+    }
+
+    /// Set the max number of loops during polling measurement.
+    ///
+    /// Default = 500;
+    pub fn set_poll_max_loop(&mut self, max_loop: u16) {
+        self.poll_max_loop = max_loop;
+    }
+    /// The range max convergence time (ms) is made up of the convergence time and sampling period.
+    ///
+    /// Min = 2ms; Max = 63ms; Default = 49ms
+    ///
+    /// Reducing the max convergence time will reduce the maximum time a measurement will be
+    /// allowed to complete and can reduce the power consumption when no target is present. We
+    /// recommend a value of 30ms for the max convergence time as a suitable starting point.
+    pub fn set_range_max_convergence_time(&mut self, time_ms: u8) -> Result<(), Error<()>> {
+        if time_ms < 2 || time_ms > 63 {
+            return Err(Error::InvalidConfigurationValue(time_ms as u16));
+        }
+        self.range_max_convergence_time = time_ms;
+        Ok(())
+    }
+
+    /// Set the period between each range measurement in continuous mode.
+    ///
+    /// Min = whichever is larger: 10ms OR the smallest value that satisfies the following equation:
+    /// [range_max_convergence_time](Config::set_range_max_convergence_time) + 5
+    /// ≤ `range_inter_measurement_period` * 0.9
+    ///
+    /// Max = 2550ms; Default = 100ms;
+    ///
+    /// Value must be a multiple of 10ms.
+    ///
+    /// The intermeasurement period needs to be set to a value that is above the maximum
+    /// allowable full ranging cycle period.
+    pub fn set_range_inter_measurement_period(&mut self, time_ms: u16) -> Result<(), Error<()>> {
+        let min_eq_val = ((self.range_max_convergence_time + 5) as f32 / 0.9) as u16;
+        let min = if 10 < min_eq_val { min_eq_val } else { 10 };
+        if time_ms % 10 != 0 || time_ms < min || time_ms > 2550 {
+            return Err(Error::InvalidConfigurationValue(time_ms));
+        }
+        self.range_inter_measurement_period = time_ms;
+        Ok(())
+    }
+
+    /// Set the readout averaging period multiplier.
+    ///
+    /// Sampling period = 1.3ms + 64.5μs * `readout_averaging_period_multiplier`
+    ///
+    /// Default = 48 which will give a sampling period of 4.4ms.
+    /// Lower settings will result in increased noise.
+    pub fn set_readout_averaging_period_multiplier(&mut self, time_ms: u8) {
+        self.readout_averaging_period_multiplier = time_ms;
+    }
+
+    /// Set the range Very High Voltage (VHV) recalibration rate.
+    ///
+    /// A VHV calibration is run once at power-up and then automatically
+    /// after every `rate_vhv` range measurements. AutoVHV can be disabled
+    /// by setting this register to 0.
+    pub fn set_vhv_recalibration_rate(&mut self, rate_vhv: u8) {
+        self.range_vhv_recalibration_rate = rate_vhv;
+    }
+
+    /// Set ambient result scaler
+    /// Min = 1x; Max = 15x; Default = 1x
+    ///
+    /// VL6180X datatsheet: Section 2.10.7 Scaler and 6.2.54
+    ///
+    /// In addition to analogue gain, the VL6180X has a scaler that multiplies the ALS count prior to the result being read.
+    /// This value, in addition to the analogue gain is useful in very low light conditions to increase the dynamic range.
+    pub fn set_ambient_result_scaler(&mut self, scaler: u8) -> Result<(), Error<()>> {
+        if scaler < 1 || scaler > 15 {
+            return Err(Error::InvalidConfigurationValue(scaler as u16));
+        }
+        self.ambient_scaling = scaler;
+        Ok(())
+    }
+
+    /// Set range scaling factor.
+    ///
+    /// Min = 1x; Max = 3x; Default = 1x
+    ///
+    /// The sensor uses 1x scaling by default, giving range
+    /// measurements in units of mm. Increasing the scaling to 2x or 3x makes it give
+    /// raw values in units of 2 mm or 3 mm instead. In other words, a bigger scaling
+    /// factor increases the sensor's potential maximum range but reduces its
+    /// resolution.
+    pub fn set_range_result_scaler(&mut self, scaler: u8) -> Result<(), Error<()>> {
+        if scaler < 1 || scaler > 3 {
+            return Err(Error::InvalidConfigurationValue(scaler as u16));
+        }
+        self.range_scaling = scaler;
+        Ok(())
+    }
+
+    /// Set the analogue gain for the ambient light sensor
+    ///
+    /// Level Min = 0; Max = 7; Default = 0
+    ///
+    /// 0: ALS Gain = 1.01
+    ///
+    /// 1: ALS Gain = 1.28
+    ///
+    /// 2: ALS Gain = 1.72
+    ///
+    /// 3: ALS Gain = 2.60
+    ///
+    /// 4: ALS Gain = 5.21
+    ///
+    /// 5: ALS Gain = 10.32
+    ///
+    /// 6: ALS Gain = 20
+    ///
+    /// 7: ALS Gain = 40
+    pub fn set_ambient_analogue_gain_level(&mut self, level: u8) -> Result<(), Error<()>> {
+        if level > 7 {
+            return Err(Error::InvalidConfigurationValue(level as u16));
+        }
+        self.ambient_analogue_gain_level = level;
+        Ok(())
+    }
+
+    /// Set the integration period for ambient light measurement
+    ///
+    /// Min = 1ms; Max = 256ms; Default = 100ms
+    ///
+    /// The integration period is the time over which a single ambient light
+    /// measurement is made. Integration times in the range 50-100ms are
+    /// recommended to reduce impact of light flicker from artificial lighting
+    pub fn set_ambient_integration_period(&mut self, time_ms: u16) -> Result<(), Error<()>> {
+        if time_ms < 1 || time_ms > 256 {
+            return Err(Error::InvalidConfigurationValue(time_ms as u16));
+        }
+        self.ambient_integration_period = time_ms;
+        Ok(())
+    }
+
+    /// Set the period between each ambient measurement in continuous mode.
+    ///
+    /// Min = whichever is larger: 10ms OR the smallest value that satisfies the following equation:
+    /// [ambient_integration_period](Config::set_ambient_integration_period) * 1.1
+    /// ≤ `ambient_inter_measurement_period` * 0.9
+    ///
+    /// Max = 2550ms; Default = 500ms; Value must be a multiple of 10ms.
+    ///
+    /// Note: for interleaved mode, the following equation must be satisfied:
+    ///
+    /// ([range_max_convergence_time](Config::set_range_max_convergence_time) + 5) +
+    /// ([ambient_integration_period](Config::set_ambient_integration_period) * 1.1)
+    /// ≤ `ambient_inter_measurement_period` * 0.9
+    ///
+    /// The interleaved requirement is only checked when the interleaved mode is started.
+    pub fn set_ambient_inter_measurement_period(&mut self, time_ms: u16) -> Result<(), Error<()>> {
+        let min_eq_val = ((self.ambient_integration_period as f32 * 1.1) / 0.9) as u16;
+        let min = if 10 < min_eq_val { min_eq_val } else { 10 };
+        if time_ms % 10 != 0 || time_ms < min || time_ms > 2560 {
+            return Err(Error::InvalidConfigurationValue(time_ms));
+        }
+        self.ambient_inter_measurement_period = time_ms;
+        Ok(())
+    }
+
+    /// Set the range interrupt mode. Possible values:
+    ///
+    /// Disabled
+    ///
+    /// Level Low (value < thresh_low)
+    ///
+    /// Level High (value > thresh_high)
+    ///
+    /// Out Of Window (value < thresh_low OR value > thresh_high)
+    ///
+    /// New Sample Ready (this is the default)
+    pub fn set_range_interrupt_mode(&mut self, interrupt_mode: RangeInterruptMode) {
+        self.range_interrupt_mode = interrupt_mode;
+    }
+
+    /// Set the low threshold for range interrupt.
+    ///
+    /// Default = 0;
+    ///
+    /// Note: This value will be multiplied by the [range_result_scaler](Config::set_range_result_scaler) used
+    pub fn set_range_low_interrupt_threshold(&mut self, threshold: u8) {
+        self.range_low_interrupt_threshold = threshold;
+    }
+
+    /// Set the high threshold for range interrupt.
+    ///
+    /// Default = 255;
+    ///
+    /// Note: This value will be multiplied by the [range_result_scaler](Config::set_range_result_scaler) used
+    pub fn set_range_high_interrupt_threshold(&mut self, threshold: u8) {
+        self.range_high_interrupt_threshold = threshold;
+    }
+
+    /// Set the ambient light sensor interrupt mode. Possible values:
+    ///
+    /// Disabled
+    ///
+    /// Level Low (value < thresh_low)
+    ///
+    /// Level High (value > thresh_high)
+    ///
+    /// Out Of Window (value < thresh_low OR value > thresh_high)
+    ///
+    /// New Sample Ready (this is the default)
+    pub fn set_ambient_interrupt_mode(&mut self, interrupt_mode: AmbientInterruptMode) {
+        self.ambient_interrupt_mode = interrupt_mode;
+    }
+
+    /// Set the low threshold for ambient interrupt.
+    ///
+    /// Default = 0x0;
+    ///
+    /// Note: Threshold is in raw device value not lux.
+    /// This value will be multiplied by the [ambient_result_scaler](Config::set_ambient_result_scaler) used
+    pub fn set_ambient_low_interrupt_threshold(&mut self, threshold: u16) {
+        self.ambient_low_interrupt_threshold = threshold;
+    }
+
+    /// Set the high threshold for ambient interrupt.
+    ///
+    /// Default = 0xFFFF;
+    ///
+    /// Note: Threshold is in raw device value not lux.
+    /// This value will be multiplied by the [ambient_result_scaler](Config::set_ambient_result_scaler) used
+    pub fn set_ambient_high_interrupt_threshold(&mut self, threshold: u16) {
+        self.ambient_high_interrupt_threshold = threshold;
+    }
+
+    /// Set the i2c address for the initial connection
+    pub fn set_i2c_address(&mut self, address: u8) {
+        self.address = address;
+    }
+
+    // TODO: 6.2 Additional error checks
+}

--- a/src/config/config_tests.rs
+++ b/src/config/config_tests.rs
@@ -1,0 +1,32 @@
+use super::*;
+
+#[test]
+fn bitwise_or_interrupt_modes() {
+    let val = AmbientInterruptMode::NewSampleReady as u8 | RangeInterruptMode::NewSampleReady as u8;
+    assert_eq!(val, 0x24)
+}
+
+#[test]
+fn set_range_max_convergence_time_value_too_small() {
+    let mut config = Config::new();
+    assert_eq!(
+        config.set_range_max_convergence_time(1).err().unwrap(),
+        Error::InvalidConfigurationValue(1)
+    )
+}
+
+#[test]
+fn set_range_max_convergence_time_value_too_high() {
+    let mut config = Config::new();
+    assert_eq!(
+        config.set_range_max_convergence_time(64).err().unwrap(),
+        Error::InvalidConfigurationValue(64)
+    )
+}
+
+#[test]
+fn set_range_max_convergence_time_value_valid() {
+    let mut config = Config::new();
+    assert_eq!(config.set_range_max_convergence_time(20), Ok(()))
+}
+

--- a/src/device_status.rs
+++ b/src/device_status.rs
@@ -1,0 +1,97 @@
+use super::VL6180X;
+use crate::{
+    error::{Error, Error2},
+    register::{Register8Bit::*, SysInterruptClearCode},
+};
+use embedded_hal::{
+    blocking::i2c::{Write, WriteRead},
+    digital::v2::OutputPin,
+};
+
+impl<MODE, I2C, E> VL6180X<MODE, I2C>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+{
+    pub(crate) fn read_model_id_direct(&mut self) -> Result<u8, Error<E>> {
+        let id = self.read_named_register(IDENTIFICATION__MODEL_ID)?;
+        Ok(id)
+    }
+
+    pub(crate) fn read_interrupt_status_direct(&mut self) -> Result<u8, Error<E>> {
+        let status = self.read_named_register(RESULT__INTERRUPT_STATUS_GPIO)?;
+        return Ok(status);
+    }
+
+    pub(crate) fn clear_error_interrupt_direct(&mut self) -> Result<(), Error<E>> {
+        self.clear_interrupt(SysInterruptClearCode::Error as u8)?;
+        Ok(())
+    }
+
+    pub(crate) fn clear_ambient_interrupt_direct(&mut self) -> Result<(), Error<E>> {
+        self.clear_interrupt(SysInterruptClearCode::Ambient as u8)?;
+        Ok(())
+    }
+
+    pub(crate) fn clear_range_interrupt_direct(&mut self) -> Result<(), Error<E>> {
+        self.clear_interrupt(SysInterruptClearCode::Range as u8)?;
+        Ok(())
+    }
+
+    pub(crate) fn clear_all_interrupts_direct(&mut self) -> Result<(), Error<E>> {
+        self.clear_interrupt(
+            SysInterruptClearCode::Range as u8
+                | SysInterruptClearCode::Ambient as u8
+                | SysInterruptClearCode::Error as u8,
+        )?;
+        Ok(())
+    }
+
+    fn clear_interrupt(&mut self, code: u8) -> Result<(), E> {
+        self.write_named_register(SYSTEM__INTERRUPT_CLEAR, code)
+    }
+
+    pub(crate) fn change_i2c_address_direct(&mut self, new_address: u8) -> Result<(), Error<E>> {
+        if new_address < 0x08 || new_address > 0x77 {
+            return Err(Error::InvalidAddress(new_address));
+        }
+        self.write_only_named_register(I2C_SLAVE__DEVICE_ADDRESS, new_address)?;
+        self.config.address = new_address;
+
+        Ok(())
+    }
+
+    pub(crate) fn power_off_direct<PE, P: OutputPin<Error = PE>>(
+        &self,
+        x_shutdown_pin: &mut P,
+    ) -> Result<(), Error<PE>> {
+        x_shutdown_pin.set_low().map_err(|e| Error::GpioPinError(e))
+    }
+
+    pub(crate) fn power_on_and_init_direct<PE, P: OutputPin<Error = PE>>(
+        &mut self,
+        x_shutdown_pin: &mut P,
+    ) -> Result<(), Error2<E, PE>> {
+        x_shutdown_pin
+            .set_high()
+            .map_err(|e| Error2::GpioPinError(e))?;
+        self.wait_device_booted()
+            .map_err(|e| Error2::<E, PE>::BusError(e))?;
+        self.init_hardware()
+            .map_err(|e| Error2::<E, PE>::BusError(e))?;
+        Ok(())
+    }
+
+    fn wait_device_booted(&mut self) -> Result<(), E> {
+        loop {
+            match self.read_named_register(SYSTEM__FRESH_OUT_OF_RESET) {
+                Ok(result) => {
+                    if result == 0x01 {
+                        break;
+                    }
+                }
+                Err(_) => (),
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,52 @@
+use crate::mode;
+pub use crate::register::{AmbientStatusErrorCode, RangeStatusErrorCode};
+/// MPU Error
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum Error<E> {
+    /// WHO_AM_I returned invalid value (returned value is argument).
+    InvalidDevice(u8),
+    /// Underlying bus error.
+    BusError(E),
+    /// Timeout.
+    Timeout,
+    /// I2C address not valid, needs to be between 0x08 and 0x77.
+    /// It is a 7 bit address thus the range is 0x00 - 0x7F but
+    /// 0x00 - 0x07 and 0x78 - 0x7F are reserved I2C addresses and cannot be used.
+    InvalidAddress(u8),
+    /// Invalid configuration value.
+    InvalidConfigurationValue(u16),
+    /// The measurement reading is not ready.
+    ResultNotReady,
+    /// Error reading the range measurement.
+    RangeStatusError(RangeStatusErrorCode),
+    /// Error reading the ambient light measurement.
+    AmbientStatusError(AmbientStatusErrorCode),
+    /// Error converting a code read from a register to it's enum form.
+    UnknownRegisterCode(u8),
+    /// DynamicMode method call invalid for current operating mode.
+    InvalidMethod(mode::dynamic::OperatingMode),
+    /// Error when setting pin output state.
+    GpioPinError(E),
+}
+/// Test
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum Error2<E, F> {
+    /// Underlying bus error.
+    BusError(E),
+    /// DynamicMode method call invalid for current operating mode.
+    InvalidMethod(mode::dynamic::OperatingMode),
+    /// Error when setting pin output state.
+    GpioPinError(F),
+}
+
+impl<E, F> From<E> for Error2<E, F> {
+    fn from(error: E) -> Self {
+        Error2::BusError(error)
+    }
+}
+
+impl<E> From<E> for Error<E> {
+    fn from(error: E) -> Self {
+        Error::BusError(error)
+    }
+}

--- a/src/i2c_interface.rs
+++ b/src/i2c_interface.rs
@@ -1,0 +1,120 @@
+use super::*;
+use crate::register::{Register16Bit, Register8Bit};
+
+impl<MODE, I2C, E> VL6180X<MODE, I2C>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+{
+    /// Reads a named 8-bit register
+    pub(crate) fn read_named_register(&mut self, reg: Register8Bit) -> Result<u8, E> {
+        self.read_register(reg as u16)
+    }
+
+    /// Reads an 8-bit register
+    fn read_register(&mut self, reg: u16) -> Result<u8, E> {
+        let mut data: [u8; 1] = [0];
+        let reg: [u8; 2] = reg.to_be_bytes();
+
+        self.com.write_read(self.config.address, &reg, &mut data)?;
+        Ok(data[0])
+    }
+
+    /// Reads a named 16-bit register
+    pub(crate) fn read_named_register_16bit(&mut self, reg: Register16Bit) -> Result<u16, E> {
+        self.read_register_16bit(reg as u16)
+    }
+
+    /// Reads a 16-bit register
+    fn read_register_16bit(&mut self, reg: u16) -> Result<u16, E> {
+        let mut data: [u8; 2] = [0, 0];
+        let reg: [u8; 2] = reg.to_be_bytes();
+
+        self.com.write_read(self.config.address, &reg, &mut data)?;
+        Ok(u16::from_be_bytes(data))
+    }
+
+    /// Reads a named 32-bit register
+    fn read_named_register_32bit(&mut self, reg: Register16Bit) -> Result<u32, E> {
+        self.read_register_32bit(reg as u16)
+    }
+
+    /// Reads a 32-bit register
+    fn read_register_32bit(&mut self, reg: u16) -> Result<u32, E> {
+        let mut data: [u8; 4] = [0, 0, 0, 0];
+        let reg: [u8; 2] = reg.to_be_bytes();
+
+        self.com.write_read(self.config.address, &reg, &mut data)?;
+        Ok(u32::from_be_bytes(data))
+    }
+
+    pub(super) fn write_only_named_register(
+        &mut self,
+        reg: Register8Bit,
+        code: u8,
+    ) -> Result<(), E> {
+        self.write_only_register(reg as u16, code)
+    }
+
+    pub(super) fn write_only_register(&mut self, reg: u16, code: u8) -> Result<(), E> {
+        let reg = reg.to_be_bytes();
+        let bytes: [u8; 3] = [reg[0], reg[1], code];
+        self.com.write(self.config.address, &bytes)
+    }
+
+    pub(super) fn write_named_register(&mut self, reg: Register8Bit, code: u8) -> Result<(), E> {
+        self.write_register(reg as u16, code)
+    }
+
+    pub(super) fn write_register(&mut self, reg: u16, code: u8) -> Result<(), E> {
+        let mut buffer = [0];
+        let reg = reg.to_be_bytes();
+        let bytes: [u8; 3] = [reg[0], reg[1], code];
+        self.com
+            .write_read(self.config.address, &bytes, &mut buffer)
+    }
+
+    pub(super) fn write_named_register_16bit(
+        &mut self,
+        reg: Register16Bit,
+        code: u16,
+    ) -> Result<(), E> {
+        self.write_register_16bit(reg as u16, code)
+    }
+
+    fn write_register_16bit(&mut self, reg: u16, code: u16) -> Result<(), E> {
+        let mut buffer = [0];
+        let code = code.to_be_bytes();
+        let reg = reg.to_be_bytes();
+        let bytes: [u8; 4] = [reg[0], reg[1], code[0], code[1]];
+        self.com
+            .write_read(self.config.address, &bytes, &mut buffer)
+    }
+
+    pub(super) fn write_named_register_32bit(
+        &mut self,
+        reg: Register16Bit,
+        code: u32,
+    ) -> Result<(), E> {
+        self.write_register_32bit(reg as u32, code)
+    }
+
+    fn write_register_32bit(&mut self, reg: u32, code: u32) -> Result<(), E> {
+        let mut buffer = [0];
+        let code = code.to_be_bytes();
+        let reg = reg.to_be_bytes();
+        let bytes: [u8; 6] = [reg[0], reg[1], code[0], code[1], code[2], code[3]];
+        self.com
+            .write_read(self.config.address, &bytes, &mut buffer)
+    }
+
+    // fn write_6bytes(&mut self, reg: Register8Bit, bytes: [u8; 6]) -> Result<(), E> {
+    //     let mut buf: [u8; 6] = [0, 0, 0, 0, 0, 0];
+    //     self.com.write_read(
+    //         self.config.address,
+    //         &[
+    //             reg as u8, bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5],
+    //         ],
+    //         &mut buf,
+    //     )
+    // }
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,0 +1,177 @@
+use super::VL6180X;
+use crate::register::{
+    Register16Bit::*, Register8Bit::*, SysModeGpio1Polarity, SysModeGpio1Select,
+    AMBIENT_ANALOGUE_GAIN_CODE, RANGE_SCALAR_CODE,
+};
+use embedded_hal::blocking::i2c::{Write, WriteRead};
+
+impl<MODE, I2C, E> VL6180X<MODE, I2C>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+{
+    /// Initialize sensor with settings from ST application note AN4545,
+    /// section "SR03 settings" - "Mandatory : private registers"
+    pub(crate) fn init_hardware(&mut self) -> Result<(), E> {
+        // Store part-to-part range offset so it can be adjusted if scaling is changed
+        self.config.ptp_offset = self.read_named_register(SYSRANGE__PART_TO_PART_RANGE_OFFSET)?;
+
+        self.write_register(0x207, 0x01)?;
+        self.write_register(0x208, 0x01)?;
+        self.write_register(0x096, 0x00)?;
+        self.write_register(0x097, 0xFD)?; // RANGE_SCALER = 253
+        self.write_register(0x0E3, 0x01)?;
+        self.write_register(0x0E4, 0x03)?;
+        self.write_register(0x0E5, 0x02)?;
+        self.write_register(0x0E6, 0x01)?;
+        self.write_register(0x0E7, 0x03)?;
+        self.write_register(0x0F5, 0x02)?;
+        self.write_register(0x0D9, 0x05)?;
+        self.write_register(0x0DB, 0xCE)?;
+        self.write_register(0x0DC, 0x03)?;
+        self.write_register(0x0DD, 0xF8)?;
+        self.write_register(0x09F, 0x00)?;
+        self.write_register(0x0A3, 0x3C)?;
+        self.write_register(0x0B7, 0x00)?;
+        self.write_register(0x0BB, 0x3C)?;
+        self.write_register(0x0B2, 0x09)?;
+        self.write_register(0x0CA, 0x09)?;
+        self.write_register(0x198, 0x01)?;
+        self.write_register(0x1B0, 0x17)?;
+        self.write_register(0x1AD, 0x00)?;
+        self.write_register(0x0FF, 0x05)?;
+        self.write_register(0x100, 0x05)?;
+        self.write_register(0x199, 0x05)?;
+        self.write_register(0x1A6, 0x1B)?;
+        self.write_register(0x1AC, 0x3E)?;
+        self.write_register(0x1A7, 0x1F)?;
+        self.write_register(0x030, 0x00)?;
+
+        self.write_named_register(SYSTEM__FRESH_OUT_OF_RESET, 0)?;
+
+        self.set_configuration()?;
+
+        Ok(())
+    }
+
+    /// See VL6180X datasheet and application note to understand how the config
+    /// values get transformed into the values the registers are set to.
+    fn set_configuration(&mut self) -> Result<(), E> {
+        self.write_named_register(
+            READOUT__AVERAGING_SAMPLE_PERIOD,
+            self.config.readout_averaging_period_multiplier,
+        )?;
+
+        self.write_named_register(
+            SYSALS__ANALOGUE_GAIN,
+            AMBIENT_ANALOGUE_GAIN_CODE[self.config.ambient_analogue_gain_level as usize],
+        )?;
+
+        self.write_named_register(FIRMWARE__RESULT_SCALER, self.config.ambient_scaling)?;
+
+        self.write_named_register(
+            SYSRANGE__VHV_REPEAT_RATE,
+            self.config.range_vhv_recalibration_rate,
+        )?;
+
+        let integration_period_val = self.config.ambient_integration_period - 1;
+        self.write_named_register_16bit(SYSALS__INTEGRATION_PERIOD, integration_period_val)?;
+
+        let ambient_inter_measurement_val =
+            ((self.config.ambient_inter_measurement_period / 10) as u8) - 1;
+        self.write_named_register(
+            SYSALS__INTERMEASUREMENT_PERIOD,
+            ambient_inter_measurement_val,
+        )?;
+
+        // Manually trigger a range VHV recalibration
+        self.write_named_register(SYSRANGE__VHV_RECALIBRATE, 0x01)?;
+
+        let range_inter_measurement_val =
+            ((self.config.range_inter_measurement_period / 10) as u8) - 1;
+        self.write_named_register(
+            SYSRANGE__INTERMEASUREMENT_PERIOD,
+            range_inter_measurement_val,
+        )?;
+
+        self.set_interrupts()?;
+
+        self.write_named_register(
+            SYSRANGE__MAX_CONVERGENCE_TIME,
+            self.config.range_max_convergence_time,
+        )?;
+
+        // disable interleaved mode
+        self.write_named_register(INTERLEAVED_MODE__ENABLE, 0)?;
+
+        self.set_range_scaling(self.config.range_scaling)?;
+
+        Ok(())
+    }
+
+    fn set_interrupts(&mut self) -> Result<(), E> {
+        // Set the interrupt mode
+        let interrupt_val =
+            self.config.range_interrupt_mode as u8 | self.config.ambient_interrupt_mode as u8;
+        self.write_named_register(SYSTEM__INTERRUPT_CONFIG_GPIO, interrupt_val)?;
+
+        // Enable or disable GPIO1 as interrupt output
+        if interrupt_val != 0x00 {
+            self.write_named_register(
+                SYSTEM__MODE_GPIO1,
+                SysModeGpio1Polarity::ActiveHigh as u8 | SysModeGpio1Select::InterruptOutput as u8,
+            )?;
+        } else {
+            self.write_named_register(
+                SYSTEM__MODE_GPIO1,
+                SysModeGpio1Polarity::ActiveHigh as u8 | SysModeGpio1Select::Off as u8,
+            )?;
+        }
+
+        // Set the thresholds
+        self.write_named_register(
+            SYSRANGE__THRESH_HIGH,
+            self.config.range_high_interrupt_threshold,
+        )?;
+        self.write_named_register(
+            SYSRANGE__THRESH_LOW,
+            self.config.range_low_interrupt_threshold,
+        )?;
+        self.write_named_register_16bit(
+            SYSALS__THRESH_HIGH,
+            self.config.ambient_high_interrupt_threshold,
+        )?;
+        self.write_named_register_16bit(
+            SYSALS__THRESH_LOW,
+            self.config.ambient_low_interrupt_threshold,
+        )?;
+
+        Ok(())
+    }
+    fn set_range_scaling(&mut self, new_scaling: u8) -> Result<(), E> {
+        const DEFAULT_CROSSTALK_VALID_HEIGHT: u8 = 20; // default value of SYSRANGE__CROSSTALK_VALID_HEIGHT
+
+        let scaling = new_scaling;
+        self.write_named_register_16bit(RANGE_SCALER, RANGE_SCALAR_CODE[scaling as usize])?;
+
+        // apply scaling on part-to-part offset
+        self.write_named_register(
+            SYSRANGE__PART_TO_PART_RANGE_OFFSET,
+            self.config.ptp_offset / scaling,
+        )?;
+
+        // apply scaling on CrossTalkValidHeight
+        self.write_named_register(
+            SYSRANGE__CROSSTALK_VALID_HEIGHT,
+            DEFAULT_CROSSTALK_VALID_HEIGHT / scaling,
+        )?;
+
+        // This function does not apply scaling to RANGE_IGNORE_VALID_HEIGHT.
+
+        // enable early convergence estimate only at 1x scaling
+        let rce = self.read_named_register(SYSRANGE__RANGE_CHECK_ENABLES)?;
+        let is_scaling_one: u8 = if scaling == 1 { 1 } else { 0 };
+        self.write_named_register(SYSRANGE__RANGE_CHECK_ENABLES, (rce & 0xFE) | is_scaling_one)?;
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,66 @@
-#![no_std]
-
 //! Manages a new VL6180X, Time-of-Flight I2C laser-ranging module
+//! ## Examples
+//!
+//! for more examples please see [vl6180x_stm32f401_examples](https://github.com/shaoyuancc/vl6180x_stm32f401_examples)
+//!
+//! ```rust
+//! #![no_std]
+//! #![no_main]
+//!
+//! use cortex_m_rt::ExceptionFrame;
+//! use cortex_m_rt::{entry, exception};
+//! use cortex_m_semihosting::hprintln;
+//! use hal::{pac, prelude::*};
+//! use panic_semihosting as _;
+//! use stm32f4xx_hal as hal;
+//! use vl6180x;
+//!
+//! #[entry]
+//! fn main() -> ! {
+//!     if let (Some(dp), Some(_cp)) = (
+//!         pac::Peripherals::take(),
+//!         cortex_m::peripheral::Peripherals::take(),
+//!     ) {
+//!         let rcc = dp.RCC.constrain();
+//!         let clocks = rcc.cfgr.sysclk(48.MHz()).freeze();
+//!
+//!         let gpiob = dp.GPIOB.split();
+//!         let scl = gpiob
+//!             .pb8
+//!             .into_alternate()
+//!             .internal_pull_up(true)
+//!             .set_open_drain();
+//!         let sda = gpiob
+//!             .pb9
+//!             .into_alternate()
+//!             .internal_pull_up(true)
+//!             .set_open_drain();
+//!         let i2c = dp.I2C1.i2c((scl, sda), 400.kHz(), &clocks);
+//!
+//!         //! To create sensor with default configuration:
+//!         let mut tof = vl6180x::VL6180X::new(i2c).expect("vl");
+//!
+//!         loop {
+//!             match tof.poll_range_mm_single_blocking() {
+//!                 Ok(range) => hprintln!("Range Single Poll: {}mm", range).unwrap(),
+//!                 Err(e) => hprintln!("Error reading TOF sensor Single Poll! {:?}", e).unwrap(),
+//!             }
+//!         }
+//!     }
+//!     loop {}
+//! }
 
+//! #[exception]
+//! unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
+//!     panic!("{:#?}", ef);
+//! }
+//! ```
+
+//! ## References
+//! [VL6180X datasheet](https://www.st.com/resource/en/datasheet/vl6180x.pdf) (Time-of-Flight I2C laser-ranging module)
+//! [ST application note AN4545](https://www.st.com/resource/en/application_note/an4545-vl6180x-basic-ranging-application-note-stmicroelectronics.pdf)
+
+#![no_std]
 #![deny(
     missing_docs,
     missing_debug_implementations,
@@ -13,15 +72,40 @@
     warnings
 )]
 #![allow(dead_code)]
+pub use crate::register::ResultInterruptStatusGpioCode;
+pub use config::*;
+use embedded_hal::blocking::i2c::{Write, WriteRead};
+use embedded_hal::digital::v2::{InputPin, OutputPin};
+pub use error::Error;
+pub use mode::*;
+mod config;
+mod device_status;
+mod error;
+mod i2c_interface;
+mod init;
+mod mode;
+mod read_measurements;
+mod register;
+mod start_stop_measurements;
 
-/// Sometimes it's correct (0x29 << 1) instead of 0x29
-const ADDRESS_DEFAULT: u8 = 0x29;
-
-/// Struct for VL6180X state
+/// VL6180 interface
 #[derive(Debug, Clone, Copy)]
-pub struct VL6180X {
-    io_mode2v8: bool,
-    stop_variable: u8,
-    measurement_timing_budget_microseconds: u32,
-    address: u8,
+pub struct VL6180X<MODE, I2C: Write + WriteRead> {
+    mode: MODE,
+    com: I2C,
+    config: Config,
+}
+
+/// Convenience container for VL6180, x_shutdown_pin and interrupt_pin
+#[derive(Debug, Clone, Copy)]
+pub struct VL6180XwPins<MODE, I2C: Write + WriteRead, OP: OutputPin, IP: InputPin> {
+    /// VL6180
+    pub vl6180x: VL6180X<MODE, I2C>,
+    /// X Shutdown Pin, output high => powered on, output low => powered off.
+    /// Should call [VL6180X::power_off] and [VL6180X::power_on_and_init]
+    /// (Or the equivalent DynamicMode try methods) instead of
+    /// manually setting the output of the pin.
+    pub x_shutdown_pin: OP,
+    /// Interrupt pin for receiving interrupts from the sensor.
+    pub interrupt_pin: IP,
 }

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -1,0 +1,185 @@
+mod continuous;
+pub(crate) mod dynamic;
+mod powered_off;
+mod ready;
+
+pub use continuous::*;
+pub use dynamic::*;
+use embedded_hal::blocking::i2c::{Write, WriteRead};
+use embedded_hal::digital::v2::OutputPin;
+pub use powered_off::*;
+pub use ready::*;
+
+use crate::error::Error;
+use crate::VL6180X;
+
+impl<MODE, I2C, E> VL6180X<MODE, I2C>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+{
+    fn into_mode<MODE2>(self, mode: MODE2) -> VL6180X<MODE2, I2C> {
+        VL6180X {
+            mode,
+            com: self.com,
+            config: self.config,
+        }
+    }
+}
+/// Allow communication with the device (the device is not powered off)
+pub trait AllowCommunication {}
+
+/// Operating modes with this trait have an implementation for reading measurements
+pub trait AllowReadMeasurement {}
+
+/// Operating modes with this trait have an implementation for starting a single
+/// ambient light measurement
+
+pub trait AllowStartAmbientSingle {}
+
+/// Operating modes with this trait have an implementation for starting a single
+/// range measurement
+pub trait AllowStartRangeSingle {}
+
+impl<MODE, I2C, E> VL6180X<MODE, I2C>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+    MODE: AllowReadMeasurement,
+{
+    /// Blocking read of the range mesurement.
+    /// The reading (whether single or continuous) must already have been started.
+    pub fn read_range_mm_blocking(&mut self) -> Result<u16, Error<E>> {
+        self.read_range_mm_blocking_direct()
+    }
+
+    /// Non-blocking read of the range measurement.
+    /// The reading (whether single or continuous) must already have been started.
+    /// Returns [Error::ResultNotReady] if the result is not ready.
+    pub fn read_range_mm(&mut self) -> Result<u16, Error<E>> {
+        self.read_range_mm_direct()
+    }
+
+    /// Blocking read of the ambient light mesurement.
+    /// The reading (whether single or continuous) must already have been started.
+    pub fn read_ambient_lux_blocking(&mut self) -> Result<f32, Error<E>> {
+        self.read_ambient_lux_blocking_direct()
+    }
+
+    /// Non-blocking read of the ambient light measurement.
+    /// The reading (whether single or continuous) must already have been started.
+    /// Returns [Error::ResultNotReady] if the result is not ready.
+    pub fn read_ambient_lux(&mut self) -> Result<f32, Error<E>> {
+        self.read_ambient_lux_direct()
+    }
+
+    /// Blocking read of the raw ambient light mesurement.
+    /// The reading (whether single or continuous) must already have been started.
+    pub fn read_ambient_blocking(&mut self) -> Result<u16, Error<E>> {
+        self.read_ambient_blocking_direct()
+    }
+
+    /// Non-blocking read of the raw ambient light measurement.
+    /// The reading (whether single or continuous) must already have been started.
+    /// Returns [Error::ResultNotReady] if the result is not ready.
+    pub fn read_ambient(&mut self) -> Result<u16, Error<E>> {
+        self.read_ambient_direct()
+    }
+}
+
+impl<MODE, I2C, E> VL6180X<MODE, I2C>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+    MODE: AllowStartAmbientSingle,
+{
+    /// Trigger ambient light measurement in a non-blocking way.
+    ///
+    /// Does not return the result. To get the measured value the host has the following options:
+    /// 1. Check regularly to see if the result is ready with [`read_ambient_lux`](VL6180X::read_ambient_lux)
+    /// or [`read_ambient`](VL6180X::read_ambient)
+    /// 2. Call [`read_ambient_lux_blocking`](VL6180X::read_ambient_lux_blocking) or
+    /// [`read_ambient_blocking`](VL6180X::read_ambient_blocking) to have the driver
+    /// perform the regular checks in a blocking way.
+    /// 3. Wait for the ambient interrupt to be triggered, indicating that the
+    /// new sample is ready, then call the methods listed in option 1.
+    pub fn start_ambient_single(&mut self) -> Result<(), Error<E>> {
+        self.start_ambient_single_direct()?;
+        Ok(())
+    }
+}
+
+impl<MODE, I2C, E> VL6180X<MODE, I2C>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+    MODE: AllowStartRangeSingle,
+{
+    /// Trigger range mesurement in a non-blocking way.
+    ///
+    /// Does not return the result. To get the measured value the host has the following options:
+    /// 1. Check regularly to see if the result is ready with [`read_range_mm()`](VL6180X::read_range_mm)
+    /// 2. Call [`read_range_mm_blocking()`](VL6180X::read_range_mm_blocking) to have the driver
+    /// perform the regular checks in a blocking way.
+    /// 3. Wait for the range interrupt to be triggered, indicating that the
+    /// new sample is ready, then call [`read_range_mm()`](VL6180X::read_range_mm).
+    pub fn start_range_single(&mut self) -> Result<(), Error<E>> {
+        self.start_range_single_direct()?;
+        Ok(())
+    }
+}
+
+impl<MODE, I2C, E> VL6180X<MODE, I2C>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+    MODE: AllowCommunication,
+{
+    /// Read the model id of the sensor. Should return 0xB4.
+    pub fn read_model_id(&mut self) -> Result<u8, Error<E>> {
+        self.read_model_id_direct()
+    }
+
+    /// Read the current interrupt status of the sensor.
+    /// Can be in multiple states of [ResultInterruptStatusGpioCode](crate::register::ResultInterruptStatusGpioCode) at once.
+    /// Use [ResultInterruptStatusGpioCode::has_status](crate::register::ResultInterruptStatusGpioCode::has_status) to look for particular states.
+    pub fn read_interrupt_status(&mut self) -> Result<u8, Error<E>> {
+        self.read_interrupt_status_direct()
+    }
+
+    /// Clear error interrupt
+    pub fn clear_error_interrupt(&mut self) -> Result<(), Error<E>> {
+        self.clear_error_interrupt_direct()
+    }
+
+    /// Clear ambient interrupt
+    pub fn clear_ambient_interrupt(&mut self) -> Result<(), Error<E>> {
+        self.clear_ambient_interrupt_direct()
+    }
+
+    /// Clear range interrupt
+    pub fn clear_range_interrupt(&mut self) -> Result<(), Error<E>> {
+        self.clear_range_interrupt_direct()
+    }
+
+    /// Clear all interrupts (error, ambient and range)
+    pub fn clear_all_interrupts(&mut self) -> Result<(), Error<E>> {
+        self.clear_all_interrupts_direct()
+    }
+
+    /// Powers off the sensor by setting the `x_shutdown_pin` low.
+    pub fn power_off<PE, P: OutputPin<Error = PE>>(
+        self,
+        x_shutdown_pin: &mut P,
+    ) -> Result<VL6180X<PoweredOffMode, I2C>, Error<PE>> {
+        self.power_off_direct(x_shutdown_pin)?;
+        Ok(self.into_mode(PoweredOffMode {}))
+    }
+
+    /// Change current i2c address to new i2c address.
+    ///
+    /// After completion the device will answer to the new address programmed.
+    /// Note that the address resets when the device is powered off.
+    /// Only allows values between 0x08 and 0x77 as the device uses a 7 bit address and
+    /// 0x00 - 0x07 and 0x78 - 0x7F are reserved
+    ///
+    /// AN4478: Using multiple VL6180X's in a single design
+    pub fn change_i2c_address(&mut self, new_address: u8) -> Result<(), Error<E>> {
+        self.change_i2c_address_direct(new_address)
+    }
+}

--- a/src/mode/continuous.rs
+++ b/src/mode/continuous.rs
@@ -1,0 +1,68 @@
+use crate::{error::Error, AllowCommunication, VL6180X};
+use embedded_hal::blocking::i2c::{Write, WriteRead};
+
+use super::{AllowReadMeasurement, AllowStartAmbientSingle, AllowStartRangeSingle, ReadyMode};
+
+/// Mode in which continuous range measurements are being taken by the sensor
+#[derive(Debug, Copy, Clone)]
+pub struct RangeContinuousMode;
+
+impl AllowReadMeasurement for RangeContinuousMode {}
+
+impl AllowStartAmbientSingle for RangeContinuousMode {}
+
+impl AllowCommunication for RangeContinuousMode {}
+
+impl<I2C, E> VL6180X<RangeContinuousMode, I2C>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+{
+    /// Stops range continuous mode.
+    pub fn stop_range_continuous_mode(mut self) -> Result<VL6180X<ReadyMode, I2C>, Error<E>> {
+        self.toggle_range_continuous_direct()?;
+        Ok(self.into_mode(ReadyMode {}))
+    }
+}
+
+/// Mode in which continuous ambient light measurements are being taken by the sensor
+#[derive(Debug, Copy, Clone)]
+pub struct AmbientContinuousMode;
+
+impl AllowReadMeasurement for AmbientContinuousMode {}
+
+impl AllowStartRangeSingle for AmbientContinuousMode {}
+
+impl AllowCommunication for AmbientContinuousMode {}
+
+impl<I2C, E> VL6180X<AmbientContinuousMode, I2C>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+{
+    /// Stops ambient continuous mode.
+    pub fn stop_ambient_continuous_mode(mut self) -> Result<VL6180X<ReadyMode, I2C>, Error<E>> {
+        self.toggle_ambient_continuous_direct()?;
+        Ok(self.into_mode(ReadyMode {}))
+    }
+}
+
+/// Mode in which continuous ambient and range measurements are being taken by the sensor.
+/// Ambient measurement is taken first, then immediately followed up by a range measurement
+/// and repeated after an interval specified by
+/// [`set_ambient_intermeasurement_period()`](crate::config::Config::set_ambient_inter_measurement_period)
+#[derive(Debug, Copy, Clone)]
+pub struct InterleavedContinuousMode {}
+
+impl AllowReadMeasurement for InterleavedContinuousMode {}
+
+impl AllowCommunication for InterleavedContinuousMode {}
+
+impl<I2C, E> VL6180X<InterleavedContinuousMode, I2C>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+{
+    /// Stops interleaved continuous mode.
+    pub fn stop_interleaved_continuous_mode(mut self) -> Result<VL6180X<ReadyMode, I2C>, Error<E>> {
+        self.stop_interleaved_continuous_direct()?;
+        Ok(self.into_mode(ReadyMode {}))
+    }
+}

--- a/src/mode/dynamic.rs
+++ b/src/mode/dynamic.rs
@@ -1,0 +1,306 @@
+use crate::error::{Error, Error2};
+use crate::VL6180X;
+use embedded_hal::{
+    blocking::i2c::{Write, WriteRead},
+    digital::v2::OutputPin,
+};
+use OperatingMode::*;
+
+/// A mode where the state is kept track of at runtime, instead of being
+/// encoded into the type. Thus allowing you to change the mode often,
+/// and without problems with ownership, or references, at the cost of some
+/// performance and the risk of runtime errors.
+#[derive(Debug, Copy, Clone)]
+pub struct DynamicMode {
+    operating_mode: OperatingMode,
+}
+
+/// Sensor operating modes that the driver uses to determine
+/// if a method call is valid in [DynamicMode](crate::mode::DynamicMode).
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum OperatingMode {
+    /// Mirrors [PoweredOffMode](crate::mode::PoweredOffMode)
+    PoweredOff,
+    /// Mirrors [Ready](crate::mode::ReadyMode)
+    Ready,
+    /// Mirrors [RangeContinuous](crate::mode::RangeContinuousMode)
+    RangeContinuous,
+    /// Mirrors [AmbientContinuous](crate::mode::AmbientContinuousMode)
+    AmbientContinuous,
+    /// Mirrors [InterleavedContinuous](crate::mode::InterleavedContinuousMode)
+    InterleavedContinuous,
+}
+
+impl DynamicMode {
+    pub(crate) fn new() -> Self {
+        Self {
+            operating_mode: Ready,
+        }
+    }
+}
+
+impl<I2C, E> VL6180X<DynamicMode, I2C>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+{
+    /// Same functionality as [`poll_range_mm_single_blocking()`](VL6180X::poll_range_mm_single_blocking)
+    /// but with a check on the current [OperatingMode].
+    /// Valid when OperatingMode is [Ready], otherwise returns [Error::InvalidMethod]
+    pub fn try_poll_range_mm_single_blocking(&mut self) -> Result<u16, Error<E>> {
+        if self.mode.operating_mode != Ready {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.poll_range_mm_single_blocking_direct()
+    }
+
+    /// Same functionality as [`poll_ambient_lux_single_blocking()`](VL6180X::poll_ambient_lux_single_blocking)
+    /// but with a check on the current [OperatingMode].
+    /// Valid when OperatingMode is [Ready], otherwise returns [Error::InvalidMethod]
+    pub fn try_poll_ambient_lux_single_blocking(&mut self) -> Result<f32, Error<E>> {
+        if self.mode.operating_mode != Ready {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.poll_ambient_lux_single_blocking_direct()
+    }
+
+    /// Same functionality as [`start_range_continuous_mode()`](VL6180X::start_range_continuous_mode)
+    /// but with a check on the current [OperatingMode].
+    /// Valid when OperatingMode is [Ready], otherwise returns [Error::InvalidMethod]
+    pub fn try_start_range_continuous_mode(&mut self) -> Result<(), Error<E>> {
+        if self.mode.operating_mode != Ready {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.toggle_range_continuous_direct()?;
+        self.mode.operating_mode = RangeContinuous;
+        Ok(())
+    }
+
+    /// Same functionality as [`stop_range_continuous_mode()`](VL6180X::stop_range_continuous_mode)
+    /// but with a check on the current [OperatingMode].
+    /// Valid when OperatingMode is [RangeContinuous], otherwise returns [Error::InvalidMethod]
+    pub fn try_stop_range_continuous_mode(&mut self) -> Result<(), Error<E>> {
+        if self.mode.operating_mode != RangeContinuous {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.toggle_range_continuous_direct()?;
+        self.mode.operating_mode = Ready;
+        Ok(())
+    }
+
+    /// Same functionality as [`start_ambient_continuous_mode()`](VL6180X::start_ambient_continuous_mode)
+    /// but with a check on the current [OperatingMode].
+    /// Valid when OperatingMode is [Ready], otherwise returns [Error::InvalidMethod]
+    pub fn try_start_ambient_continuous_mode(&mut self) -> Result<(), Error<E>> {
+        if self.mode.operating_mode != Ready {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.toggle_ambient_continuous_direct()?;
+        self.mode.operating_mode = AmbientContinuous;
+        Ok(())
+    }
+
+    /// Same functionality as [`stop_ambient_continuous_mode()`](VL6180X::stop_ambient_continuous_mode)
+    /// but with a check on the current [OperatingMode].
+    /// Valid when OperatingMode is [AmbientContinuous], otherwise returns [Error::InvalidMethod]
+    pub fn try_stop_ambient_continuous_mode(&mut self) -> Result<(), Error<E>> {
+        if self.mode.operating_mode != AmbientContinuous {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.toggle_ambient_continuous_direct()?;
+        self.mode.operating_mode = Ready;
+        Ok(())
+    }
+
+    /// Same functionality as [`start_interleaved_continuous_mode()`](VL6180X::start_interleaved_continuous_mode)
+    /// but with a check on the current [OperatingMode].
+    /// Valid when OperatingMode is [Ready], otherwise returns [Error::InvalidMethod]
+    pub fn try_start_interleaved_continuous_mode(&mut self) -> Result<(), Error<E>> {
+        if self.mode.operating_mode != Ready {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.enable_interleaved_continuous_direct()?;
+        self.mode.operating_mode = InterleavedContinuous;
+        Ok(())
+    }
+
+    /// Same functionality as [`stop_interleaved_continuous_mode()`](VL6180X::stop_interleaved_continuous_mode)
+    /// but with a check on the current [OperatingMode].
+    /// Valid when OperatingMode is [InterleavedContinuous], otherwise returns [Error::InvalidMethod]
+    pub fn try_stop_interleaved_continuous_mode(&mut self) -> Result<(), Error<E>> {
+        if self.mode.operating_mode != InterleavedContinuous {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.stop_interleaved_continuous_direct()?;
+        self.mode.operating_mode = Ready;
+        Ok(())
+    }
+
+    /// Same functionality as [`start_range_single()`](VL6180X::start_range_single)
+    /// but with a check on the current [OperatingMode].
+    /// Valid when OperatingMode is [Ready] or [AmbientContinuous],
+    /// otherwise returns [Error::InvalidMethod]
+    pub fn try_start_range_single(&mut self) -> Result<(), E> {
+        self.start_range_single_direct()
+    }
+
+    /// Same functionality as [`start_ambient_single()`](VL6180X::start_ambient_single)
+    /// but with a check on the current [OperatingMode].
+    /// Valid when OperatingMode is [Ready] or [RangeContinuous],
+    /// otherwise returns [Error::InvalidMethod]
+    pub fn try_start_ambient_single(&mut self) -> Result<(), E> {
+        self.start_ambient_single_direct()
+    }
+
+    /// Same functionality as [`read_range_mm_blocking()`](VL6180X::read_range_mm_blocking)
+    /// but with a check on the current [OperatingMode].
+    /// Valid in all OperatingModes except [PoweredOff],
+    /// in which case will return [Error::InvalidMethod]
+    pub fn try_read_range_mm_blocking(&mut self) -> Result<u16, Error<E>> {
+        if self.mode.operating_mode == PoweredOff {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.read_range_mm_blocking_direct()
+    }
+
+    /// Same functionality as [`read_range_mm()`](VL6180X::read_range_mm)
+    /// but with a check on the current [OperatingMode].
+    /// Valid in all OperatingModes except [PoweredOff],
+    /// in which case will return [Error::InvalidMethod]
+    pub fn try_read_range_mm(&mut self) -> Result<u16, Error<E>> {
+        if self.mode.operating_mode == PoweredOff {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.read_range_mm_direct()
+    }
+
+    /// Same functionality as [`read_ambient_lux_blocking()`](VL6180X::read_ambient_lux_blocking)
+    /// but with a check on the current [OperatingMode].
+    /// Valid in all OperatingModes except [PoweredOff],
+    /// in which case will return [Error::InvalidMethod]
+    pub fn try_read_ambient_lux_blocking(&mut self) -> Result<f32, Error<E>> {
+        if self.mode.operating_mode == PoweredOff {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.read_ambient_lux_blocking_direct()
+    }
+
+    /// Same functionality as [`read_ambient_lux()`](VL6180X::read_ambient_lux)
+    /// but with a check on the current [OperatingMode].
+    /// Valid in all OperatingModes except [PoweredOff],
+    /// in which case will return [Error::InvalidMethod]
+    pub fn try_read_ambient_lux(&mut self) -> Result<f32, Error<E>> {
+        if self.mode.operating_mode == PoweredOff {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.read_ambient_lux_direct()
+    }
+
+    /// Same functionality as [`read_ambient_blocking()`](VL6180X::read_ambient_blocking)
+    /// but with a check on the current [OperatingMode].
+    /// Valid in all OperatingModes except [PoweredOff],
+    /// in which case will return [Error::InvalidMethod]
+    pub fn try_read_ambient_blocking(&mut self) -> Result<u16, Error<E>> {
+        if self.mode.operating_mode == PoweredOff {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.read_ambient_blocking_direct()
+    }
+
+    /// Same functionality as [`read_ambient()`](VL6180X::read_ambient)
+    /// but with a check on the current [OperatingMode].
+    /// Valid in all OperatingModes except [PoweredOff],
+    /// in which case will return [Error::InvalidMethod]
+    pub fn try_read_ambient(&mut self) -> Result<u16, Error<E>> {
+        if self.mode.operating_mode == PoweredOff {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.read_ambient_direct()
+    }
+
+    /// Same functionality as [`clear_error_interrupt()`](VL6180X::clear_error_interrupt)
+    /// but with a check on the current [OperatingMode].
+    /// Valid in all OperatingModes except [PoweredOff],
+    /// in which case will return [Error::InvalidMethod]
+    pub fn try_clear_error_interrupt(&mut self) -> Result<(), Error<E>> {
+        if self.mode.operating_mode == PoweredOff {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.clear_error_interrupt_direct()
+    }
+
+    /// Same functionality as [`clear_ambient_interrupt()`](VL6180X::clear_ambient_interrupt)
+    /// but with a check on the current [OperatingMode].
+    /// Valid in all OperatingModes except [PoweredOff],
+    /// in which case will return [Error::InvalidMethod]
+    pub fn try_clear_ambient_interrupt(&mut self) -> Result<(), Error<E>> {
+        if self.mode.operating_mode == PoweredOff {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.clear_ambient_interrupt_direct()
+    }
+
+    /// Same functionality as [`clear_range_interrupt()`](VL6180X::clear_range_interrupt)
+    /// but with a check on the current [OperatingMode].
+    /// Valid in all OperatingModes except [PoweredOff],
+    /// in which case will return [Error::InvalidMethod]
+    pub fn try_clear_range_interrupt(&mut self) -> Result<(), Error<E>> {
+        if self.mode.operating_mode == PoweredOff {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.clear_range_interrupt_direct()
+    }
+
+    /// Same functionality as [`clear_all_interrupts()`](VL6180X::clear_all_interrupts)
+    /// but with a check on the current [OperatingMode].
+    /// Valid in all OperatingModes except [PoweredOff],
+    /// in which case will return [Error::InvalidMethod]
+    pub fn try_clear_all_interrupts(&mut self) -> Result<(), Error<E>> {
+        if self.mode.operating_mode == PoweredOff {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.clear_all_interrupts_direct()
+    }
+
+    /// Same functionality as [`change_i2c_address()`](VL6180X::change_i2c_address)
+    /// but with a check on the current [OperatingMode].
+    /// Valid in all OperatingModes except [PoweredOff],
+    /// in which case will return [Error::InvalidMethod]
+    pub fn try_change_i2c_address(&mut self, new_address: u8) -> Result<(), Error<E>> {
+        if self.mode.operating_mode == PoweredOff {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.change_i2c_address_direct(new_address)
+    }
+
+    /// Same functionality as [`power_off()`](VL6180X::power_off)
+    /// but with a check on the current [OperatingMode].
+    /// Valid in all OperatingModes except [PoweredOff],
+    /// in which case will return [Error::InvalidMethod]
+    pub fn try_power_off<PE, P: OutputPin<Error = PE>>(
+        &mut self,
+        x_shutdown_pin: &mut P,
+    ) -> Result<(), Error<PE>> {
+        if self.mode.operating_mode == PoweredOff {
+            return Err(Error::InvalidMethod(self.mode.operating_mode));
+        }
+        self.power_off_direct(x_shutdown_pin)?;
+        self.mode.operating_mode = PoweredOff;
+        Ok(())
+    }
+
+    /// Same functionality as [`power_on_and_init()`](VL6180X::power_on_and_init)
+    /// but with a check on the current [OperatingMode].
+    /// Valid when OperatingMode is [PoweredOff],
+    /// otherwise returns [Error::InvalidMethod]
+    pub fn try_power_on_and_init<PE, P: OutputPin<Error = PE>>(
+        &mut self,
+        x_shutdown_pin: &mut P,
+    ) -> Result<(), Error2<E, PE>> {
+        if self.mode.operating_mode != PoweredOff {
+            return Err(Error2::InvalidMethod(self.mode.operating_mode));
+        }
+        self.power_on_and_init_direct(x_shutdown_pin)?;
+        self.mode.operating_mode = Ready;
+        Ok(())
+    }
+}

--- a/src/mode/powered_off.rs
+++ b/src/mode/powered_off.rs
@@ -1,0 +1,25 @@
+use embedded_hal::{
+    blocking::i2c::{Write, WriteRead},
+    digital::v2::OutputPin,
+};
+
+use crate::{error::Error2, mode::ReadyMode, VL6180X};
+
+/// Mode in which the sensor is powered off.
+#[derive(Debug, Copy, Clone)]
+pub struct PoweredOffMode {}
+
+impl<I2C, E> VL6180X<PoweredOffMode, I2C>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+{
+    /// Powers on the sensor by setting the `x_shutdown_pin` high.
+    /// It then busy waits for the device to be booted and initializes the device.
+    pub fn power_on_and_init<PE, P: OutputPin<Error = PE>>(
+        mut self,
+        x_shutdown_pin: &mut P,
+    ) -> Result<VL6180X<ReadyMode, I2C>, Error2<E, PE>> {
+        self.power_on_and_init_direct(x_shutdown_pin)?;
+        Ok(self.into_mode(ReadyMode))
+    }
+}

--- a/src/mode/ready.rs
+++ b/src/mode/ready.rs
@@ -1,0 +1,104 @@
+use crate::{error::Error, Config};
+use crate::{AllowCommunication, VL6180X};
+use embedded_hal::blocking::i2c::{Write, WriteRead};
+
+use super::{
+    AllowReadMeasurement, AllowStartAmbientSingle, AllowStartRangeSingle, AmbientContinuousMode,
+    DynamicMode, InterleavedContinuousMode, RangeContinuousMode,
+};
+/// Sensor has been configured and is ready to take single measurements or switch to a
+/// continuous measurement mode
+#[derive(Debug, Copy, Clone)]
+pub struct ReadyMode;
+
+impl AllowCommunication for ReadyMode {}
+
+impl AllowReadMeasurement for ReadyMode {}
+
+impl AllowStartRangeSingle for ReadyMode {}
+
+impl AllowStartAmbientSingle for ReadyMode {}
+
+impl<I2C, E> VL6180X<ReadyMode, I2C>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+{
+    /// Create a new VL6180X driver
+    pub fn new(i2c: I2C) -> Result<Self, Error<E>> {
+        let default_config = &Config::new();
+        VL6180X::with_config(i2c, &default_config)
+    }
+
+    /// Create a new VL6180X driver cloning provided config values
+    pub fn with_config(i2c: I2C, config: &Config) -> Result<Self, Error<E>> {
+        let mut chip = Self {
+            mode: ReadyMode,
+            com: i2c,
+            config: config.clone(),
+        };
+        let chip_id = chip.read_model_id_direct()?;
+        if chip_id == 0xB4 {
+            chip.init_hardware()?;
+            Ok(chip)
+        } else {
+            Err(Error::InvalidDevice(chip_id))
+        }
+    }
+
+    /// Make VL6180X dynamic
+    ///
+    /// The modes guarantee that you can only call methods valid for each mode, but
+    /// can lead to some issues. Therefore, there is also a mode where the state is
+    /// kept track of at runtime, allowing you to change the mode often,
+    /// and without problems with ownership, or references, at the cost of some
+    /// performance and the risk of runtime errors.
+    pub fn into_dynamic_mode(self) -> VL6180X<DynamicMode, I2C> {
+        self.into_mode(DynamicMode::new())
+    }
+
+    /// Poll the sensor for a single range measurement.
+    /// Starts a single range measurement then calls [`read_range_mm_blocking`](VL6180X::read_range_mm_blocking)
+    /// to wait for the result.
+    pub fn poll_range_mm_single_blocking(&mut self) -> Result<u16, Error<E>> {
+        self.poll_range_mm_single_blocking_direct()
+    }
+
+    /// Poll the sensor for a single ambient light measurement.
+    /// Starts a single ambient measurement then calls [`read_ambient_lux_blocking`](VL6180X::read_ambient_lux_blocking)
+    /// to wait for the result.
+    pub fn poll_ambient_lux_single_blocking(&mut self) -> Result<f32, Error<E>> {
+        self.poll_ambient_lux_single_blocking_direct()
+    }
+
+    /// Starts continuous operation mode for reading range measurements.
+    ///
+    /// Main configuration values are:
+    /// 1. [range_inter_measurement_period](crate::config::Config::set_range_inter_measurement_period())
+    /// 2. [range_max_convergence_time](crate::config::Config::set_range_max_convergence_time())
+    pub fn start_range_continuous_mode(
+        self,
+    ) -> Result<VL6180X<RangeContinuousMode, I2C>, Error<E>> {
+        let mut new_vl6180x = self.into_mode(RangeContinuousMode {});
+        new_vl6180x.toggle_range_continuous_direct()?;
+        Ok(new_vl6180x)
+    }
+
+    /// Starts continuous operation mode for reading ambient light measurements.
+    pub fn start_ambient_continuous_mode(
+        self,
+    ) -> Result<VL6180X<AmbientContinuousMode, I2C>, Error<E>> {
+        let mut new_vl6180x = self.into_mode(AmbientContinuousMode {});
+        new_vl6180x.toggle_ambient_continuous_direct()?;
+        Ok(new_vl6180x)
+    }
+
+    /// Starts continuous operation mode for interleaved ambient light and range measurements.
+    /// The intermeasurement period is set by the [`ambient_inter_measurement_period`](crate::config::Config::set_ambient_inter_measurement_period)
+    pub fn start_interleaved_continuous_mode(
+        self,
+    ) -> Result<VL6180X<InterleavedContinuousMode, I2C>, Error<E>> {
+        let mut new_vl6180x = self.into_mode(InterleavedContinuousMode {});
+        new_vl6180x.enable_interleaved_continuous_direct()?;
+        Ok(new_vl6180x)
+    }
+}

--- a/src/read_measurements.rs
+++ b/src/read_measurements.rs
@@ -1,0 +1,133 @@
+use core::convert::TryFrom;
+
+use crate::{
+    error::Error,
+    register::{
+        self, AmbientStatusErrorCode, RangeStatusErrorCode, Register16Bit, Register8Bit,
+        ResultInterruptStatusGpioCode,
+    },
+    VL6180X,
+};
+use embedded_hal::blocking::i2c::{Write, WriteRead};
+
+impl<MODE, I2C, E> VL6180X<MODE, I2C>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+{
+    pub(crate) fn read_range_mm_blocking_direct(&mut self) -> Result<u16, Error<E>> {
+        let mut c = 0;
+        while ResultInterruptStatusGpioCode::has_status(
+            ResultInterruptStatusGpioCode::NoRangeEvents,
+            self.read_named_register(Register8Bit::RESULT__INTERRUPT_STATUS_GPIO)?,
+        ) {
+            c += 1;
+            if c == self.config.poll_max_loop {
+                return Err(Error::Timeout);
+            }
+        }
+
+        self.get_range_val_and_status()
+    }
+
+    pub(crate) fn read_range_mm_direct(&mut self) -> Result<u16, Error<E>> {
+        let interrupt_status =
+            self.read_named_register(Register8Bit::RESULT__INTERRUPT_STATUS_GPIO)?;
+        if ResultInterruptStatusGpioCode::has_status(
+            ResultInterruptStatusGpioCode::NoRangeEvents,
+            interrupt_status,
+        ) {
+            return Err(Error::ResultNotReady);
+        }
+        self.get_range_val_and_status()
+    }
+
+    fn get_range_val_and_status(&mut self) -> Result<u16, Error<E>> {
+        let status = self.read_named_register(Register8Bit::RESULT__RANGE_STATUS)?;
+        self.clear_range_interrupt_direct()?;
+        let error = RangeStatusErrorCode::try_from(status)
+            .map_err(|_| Error::UnknownRegisterCode(status))?;
+        if error != RangeStatusErrorCode::NoError {
+            return Err(Error::RangeStatusError(error));
+        }
+        let raw_range = self.read_named_register(Register8Bit::RESULT__RANGE_VAL)?;
+        Ok(self.convert_raw_range_to_mm(raw_range))
+    }
+
+    fn convert_raw_range_to_mm(&self, raw_range: u8) -> u16 {
+        self.config.range_scaling as u16 * raw_range as u16
+    }
+
+    pub(crate) fn read_ambient_lux_blocking_direct(&mut self) -> Result<f32, Error<E>> {
+        let mut c = 0;
+        while ResultInterruptStatusGpioCode::has_status(
+            ResultInterruptStatusGpioCode::NoAmbientEvents,
+            self.read_named_register(Register8Bit::RESULT__INTERRUPT_STATUS_GPIO)?,
+        ) {
+            c += 1;
+            if c == self.config.poll_max_loop {
+                return Err(Error::Timeout);
+            }
+        }
+        let raw_ambient = self.get_ambient_val_and_status()?;
+        Ok(self.convert_raw_ambient_to_lux(raw_ambient))
+    }
+
+    pub(crate) fn read_ambient_lux_direct(&mut self) -> Result<f32, Error<E>> {
+        if ResultInterruptStatusGpioCode::has_status(
+            ResultInterruptStatusGpioCode::NoAmbientEvents,
+            self.read_named_register(Register8Bit::RESULT__INTERRUPT_STATUS_GPIO)?,
+        ) {
+            return Err(Error::ResultNotReady);
+        }
+        let raw_ambient = self.get_ambient_val_and_status()?;
+        Ok(self.convert_raw_ambient_to_lux(raw_ambient))
+    }
+
+    pub(crate) fn read_ambient_blocking_direct(&mut self) -> Result<u16, Error<E>> {
+        let mut c = 0;
+        while ResultInterruptStatusGpioCode::has_status(
+            ResultInterruptStatusGpioCode::NoAmbientEvents,
+            self.read_named_register(Register8Bit::RESULT__INTERRUPT_STATUS_GPIO)?,
+        ) {
+            c += 1;
+            if c == self.config.poll_max_loop {
+                return Err(Error::Timeout);
+            }
+        }
+        self.get_ambient_val_and_status()
+    }
+
+    pub(crate) fn read_ambient_direct(&mut self) -> Result<u16, Error<E>> {
+        if ResultInterruptStatusGpioCode::has_status(
+            ResultInterruptStatusGpioCode::NoAmbientEvents,
+            self.read_named_register(Register8Bit::RESULT__INTERRUPT_STATUS_GPIO)?,
+        ) {
+            return Err(Error::ResultNotReady);
+        }
+        self.get_ambient_val_and_status()
+    }
+
+    fn get_ambient_val_and_status(&mut self) -> Result<u16, Error<E>> {
+        let status = self.read_named_register(Register8Bit::RESULT__ALS_STATUS)?;
+        self.clear_ambient_interrupt_direct()?;
+        let error = AmbientStatusErrorCode::try_from(status)
+            .map_err(|_| Error::UnknownRegisterCode(status))?;
+        if error != AmbientStatusErrorCode::NoError {
+            return Err(Error::AmbientStatusError(error));
+        }
+        let raw_ambient = self.read_named_register_16bit(Register16Bit::RESULT__ALS_VAL)?;
+        Ok(raw_ambient)
+    }
+
+    fn convert_raw_ambient_to_lux(&self, raw_ambient: u16) -> f32 {
+        let analogue_gain =
+            register::AMBIENT_ANALOGUE_GAIN_VALUE[self.config.ambient_analogue_gain_level as usize];
+
+        let integration_period = self.config.ambient_integration_period;
+
+        const LUX_RESOLUTION_FACTOR: f32 = 0.32_f32;
+
+        (LUX_RESOLUTION_FACTOR * 100.0 / analogue_gain)
+            * (raw_ambient as f32 / integration_period as f32)
+    }
+}

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,0 +1,286 @@
+use core::convert::TryFrom;
+use int_enum::{IntEnum, IntEnumError};
+
+#[cfg(test)]
+mod register_tests;
+
+#[allow(non_camel_case_types)]
+pub enum Register8Bit {
+    IDENTIFICATION__MODEL_ID = 0x000,
+    IDENTIFICATION__MODEL_REV_MAJOR = 0x001,
+    IDENTIFICATION__MODEL_REV_MINOR = 0x002,
+    IDENTIFICATION__MODULE_REV_MAJOR = 0x003,
+    IDENTIFICATION__MODULE_REV_MINOR = 0x004,
+    IDENTIFICATION__DATE_HI = 0x006,
+    IDENTIFICATION__DATE_LO = 0x007,
+
+    SYSTEM__MODE_GPIO0 = 0x010,
+    SYSTEM__MODE_GPIO1 = 0x011,
+    SYSTEM__HISTORY_CTRL = 0x012,
+    SYSTEM__INTERRUPT_CONFIG_GPIO = 0x014,
+    SYSTEM__INTERRUPT_CLEAR = 0x015,
+    SYSTEM__FRESH_OUT_OF_RESET = 0x016,
+    SYSTEM__GROUPED_PARAMETER_HOLD = 0x017,
+
+    SYSRANGE__START = 0x018,
+    SYSRANGE__THRESH_HIGH = 0x019,
+    SYSRANGE__THRESH_LOW = 0x01A,
+    SYSRANGE__INTERMEASUREMENT_PERIOD = 0x01B,
+    SYSRANGE__MAX_CONVERGENCE_TIME = 0x01C,
+    SYSRANGE__CROSSTALK_VALID_HEIGHT = 0x021,
+    SYSRANGE__PART_TO_PART_RANGE_OFFSET = 0x024,
+    SYSRANGE__RANGE_IGNORE_VALID_HEIGHT = 0x025,
+    SYSRANGE__MAX_AMBIENT_LEVEL_MULT = 0x02C,
+    SYSRANGE__RANGE_CHECK_ENABLES = 0x02D,
+    SYSRANGE__VHV_RECALIBRATE = 0x02E,
+    SYSRANGE__VHV_REPEAT_RATE = 0x031,
+
+    SYSALS__START = 0x038,
+    SYSALS__INTERMEASUREMENT_PERIOD = 0x03E,
+    SYSALS__ANALOGUE_GAIN = 0x03F,
+
+    RESULT__RANGE_STATUS = 0x04D,
+    RESULT__ALS_STATUS = 0x04E,
+    RESULT__INTERRUPT_STATUS_GPIO = 0x04F,
+    RESULT__RANGE_VAL = 0x062,
+    RESULT__RANGE_RAW = 0x064,
+
+    READOUT__AVERAGING_SAMPLE_PERIOD = 0x10A,
+    FIRMWARE__BOOTUP = 0x119,
+    FIRMWARE__RESULT_SCALER = 0x120,
+    I2C_SLAVE__DEVICE_ADDRESS = 0x212,
+    INTERLEAVED_MODE__ENABLE = 0x2A3,
+}
+
+#[allow(non_camel_case_types)]
+pub enum Register16Bit {
+    IDENTIFICATION__TIME = 0x008, // 16-bit
+
+    SYSRANGE__CROSSTALK_COMPENSATION_RATE = 0x01E, // 16-bit
+    SYSRANGE__EARLY_CONVERGENCE_ESTIMATE = 0x022,  // 16-bit
+    SYSRANGE__RANGE_IGNORE_THRESHOLD = 0x026,      // 16-bit
+
+    SYSALS__INTEGRATION_PERIOD = 0x040, // 16-Bit
+    SYSALS__THRESH_HIGH = 0x03A,        // 16-Bit
+    SYSALS__THRESH_LOW = 0x03C,         // 16-Bit
+
+    RESULT__ALS_VAL = 0x050,              // 16-bit
+    RESULT__HISTORY_BUFFER_0 = 0x052,     // 16-bit
+    RESULT__HISTORY_BUFFER_1 = 0x054,     // 16-bit
+    RESULT__HISTORY_BUFFER_2 = 0x056,     // 16-bit
+    RESULT__HISTORY_BUFFER_3 = 0x058,     // 16-bit
+    RESULT__HISTORY_BUFFER_4 = 0x05A,     // 16-bit
+    RESULT__HISTORY_BUFFER_5 = 0x05C,     // 16-bit
+    RESULT__HISTORY_BUFFER_6 = 0x05E,     // 16-bit
+    RESULT__HISTORY_BUFFER_7 = 0x060,     // 16-bit
+    RESULT__RANGE_RETURN_RATE = 0x066,    // 16-bit
+    RESULT__RANGE_REFERENCE_RATE = 0x068, // 16-bit
+
+    RANGE_SCALER = 0x096, // 16-bit - see STSW-IMG003 core/inc/vl6180x_def.h
+}
+
+#[allow(non_camel_case_types)]
+pub enum Register32Bit {
+    RESULT__RANGE_RETURN_SIGNAL_COUNT = 0x06C,    // 32-bit
+    RESULT__RANGE_REFERENCE_SIGNAL_COUNT = 0x070, // 32-bit
+    RESULT__RANGE_RETURN_AMB_COUNT = 0x074,       // 32-bit
+    RESULT__RANGE_REFERENCE_AMB_COUNT = 0x078,    // 32-bit
+    RESULT__RANGE_RETURN_CONV_TIME = 0x07C,       // 32-bit
+    RESULT__RANGE_REFERENCE_CONV_TIME = 0x080,    // 32-bit
+}
+
+pub enum SysModeGpio1Polarity {
+    ActiveLow = 0b00_0_0000_0,
+    ActiveHigh = 0b00_1_0000_0,
+}
+pub enum SysModeGpio1Select {
+    Off = 0b00_0_0000_0,
+    InterruptOutput = 0b00_0_1000_0,
+}
+
+/// Sets the range mode and triggers start/stop.
+///
+/// Bit 1: sysrange__mode_select: Device Mode select
+///         0: Ranging Mode Single-Shot
+///         1: Ranging Mode Continuous
+///
+/// Bit 0: sysrange__startstop: StartStop trigger based on current mode
+/// and system configuration of device_ready. FW clears register automatically.
+///         Setting this bit to 1 in single-shot mode starts a single measurement.
+///         Setting this bit to 1 in continuous mode will either start continuous
+///         operation (if stopped) or halt continuous operation (if started).
+///
+/// This bit is auto-cleared in both modes of operation.
+/// Register: SYSRANGE__START
+pub enum SysRangeStartCode {
+    SingleStart = 0b000000_01,
+    ContinuousStartOrStop = 0b000000_11,
+}
+
+/// int_clear_sig: Interrupt clear bits.
+/// Writing a 1 to each bit will clear the intended interrupt.
+pub enum SysInterruptClearCode {
+    Range = 0b00000_001,
+    Ambient = 0b00000_010,
+    Error = 0b00000_100,
+}
+
+/// Sets the ambient light mode and triggers start/stop.
+///
+/// Bit 1: sysals__mode_select: Device Mode select
+///         0: Ambient Mode Single-Shot
+///         1: Ambient Mode Continuous
+///
+/// Bit 0: sysals__startstop: StartStop trigger based on current mode
+/// and system configuration of device_ready. FW clears register automatically.
+///         Setting this bit to 1 in single-shot mode starts a single measurement.
+///         Setting this bit to 1 in continuous mode will either start continuous
+///         operation (if stopped) or halt continuous operation (if started).
+///
+/// This bit is auto-cleared in both modes of operation.
+/// Register: SYSALS__START
+pub enum SysAmbientStartCode {
+    SingleStart = 0b000000_01,
+    ContinuousStartOrStop = 0b000000_11,
+}
+
+pub enum InterleavedModeEnableCode {
+    Enable = 1,
+    Disable = 0,
+}
+
+/// Result interrupt status codes
+///
+/// Use [`has_status()`](ResultInterruptStatusGpioCode::has_status) to check if the result returned from [`read_interrupt_status()`](crate::VL6180X::read_interrupt_status)
+/// Register: RESULT__INTERRUPT_STATUS_GPIO
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum ResultInterruptStatusGpioCode {
+    /// No error reported
+    NoError, // 0b00_XXX_XXX
+    /// Laser safety error
+    LaserSafetyError = 0b01_000_000,
+    /// Phase Locked Loop (PLL) error (either PLL1 or PLL2)
+    PllError = 0b10_000_000,
+
+    /// No threshold events reported
+    NoAmbientEvents, // 0bXX_000_XXX
+    /// Low level threshold event
+    LevelLowAmbientEvent = 0b00_001_000,
+    /// High level threshold event
+    LevelHighAmbientEvent = 0b00_010_000,
+    /// Out of window threshold event
+    OutOfWindowAmbientEvent = 0b00_011_000,
+    /// New sample ready event
+    NewSampleReadyAmbientEvent = 0b00_100_000,
+
+    /// No threshold events reported
+    NoRangeEvents, // 0bXX_XXX_000
+    /// Low level threshold event
+    LevelLowRangeEvent = 0b00_000_001,
+    /// High level threshold event
+    LevelHighRangeEvent = 0b00_000_010,
+    /// Out of window threshold event
+    OutOfWindowRangeEvent = 0b00_000_011,
+    /// New sample ready event
+    NewSampleReadyRangeEvent = 0b00_000_100,
+}
+
+impl ResultInterruptStatusGpioCode {
+    /// Returns whether there is the specific event reported within the ResultInterruptStatusGpioCode
+    pub fn has_status(look_for: ResultInterruptStatusGpioCode, within: u8) -> bool {
+        const ERROR_MASK: u8 = 0b11_000_000;
+        const AMBIENT_MASK: u8 = 0b00_111_000;
+        const RANGE_MASK: u8 = 0b00_000_111;
+
+        use ResultInterruptStatusGpioCode::*;
+        match look_for {
+            NoError => within & ERROR_MASK == 0,
+            NoAmbientEvents => within & AMBIENT_MASK == 0,
+            NoRangeEvents => within & RANGE_MASK == 0,
+            _other_status => within & _other_status as u8 != 0,
+        }
+    }
+}
+
+/// Errors from performing a range measurement
+/// See VL6180X datasheet section 2.7.2 Range error codes
+/// or section 6.2.37 RESULT__RANGE_STATUS
+// Bits 7:4 of what is returned from the register
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, IntEnum, PartialEq)]
+pub enum RangeStatusErrorCode {
+    /// Valid measurement
+    NoError = 0b0000,
+    /// System error detected. No measurement possible.
+    VcselContinuityTest = 0b0001,
+    /// System error detected. No measurement possible.
+    VcselWatchdogTest = 0b0010,
+    /// System error detected. No measurement possible.
+    VcselWatchdog = 0b0011,
+    /// Phase Lock Loop 1 Lock
+    Pll1Lock = 0b0100,
+    /// Phase Lock Loop 2 Lock
+    Pll2Lock = 0b0101,
+    /// ECE check failed
+    EarlyConvergenceEstimate = 0b0110,
+    /// System did not converge before the specified max.
+    /// convergence time limit. No target detected
+    MaxConvergence = 0b0111,
+    /// Ignore threshold check failed
+    RangeIgnore = 0b1000,
+    /// Ambient conditions too high. Measurement invalidated
+    MaxSignalToNoiseRatio = 0b1011,
+    /// Range < 0 (because offset is programmable a negative range result is possible)
+    RawRangingAlgoUnderflow = 0b1100,
+    /// Result is out of range. This occurs typically around 200 mm.
+    RawRangingAlgoOverflow = 0b1101,
+    /// Range < 0 (because offset is programmable a negative range result is possible)
+    RangingAlgoUnderflow = 0b1110,
+    /// Result is out of range. This occurs typically around 200 mm.
+    RangingAlgoOverflow = 0b1111,
+}
+
+impl RangeStatusErrorCode {
+    fn has_error(within: u8) -> bool {
+        (within >> 4) != 0
+    }
+}
+
+impl TryFrom<u8> for RangeStatusErrorCode {
+    type Error = IntEnumError<Self>;
+    fn try_from(code: u8) -> Result<Self, Self::Error> {
+        RangeStatusErrorCode::from_int(code >> 4)
+    }
+}
+
+/// Errors from performing an ambient light measurement
+/// See VL6180X datasheet section 6.2.38 RESULT__ALS_STATUS
+// Bits 7:4 of what is returned from the register
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, IntEnum, PartialEq)]
+pub enum AmbientStatusErrorCode {
+    /// Valid measurement
+    NoError = 0b0000,
+    /// Overflow error
+    Overflow = 0b0001,
+    /// Underflow error
+    Underflow = 0b0010,
+}
+
+impl AmbientStatusErrorCode {
+    fn has_error(within: u8) -> bool {
+        (within >> 4) != 0
+    }
+}
+
+impl TryFrom<u8> for AmbientStatusErrorCode {
+    type Error = IntEnumError<Self>;
+    fn try_from(code: u8) -> Result<Self, Self::Error> {
+        AmbientStatusErrorCode::from_int(code >> 4)
+    }
+}
+// RANGE_SCALER values for 1x, 2x, 3x scaling - see STSW-IMG003 core/src/vl6180x_api.c (ScalerLookUP[])
+pub const RANGE_SCALAR_CODE: [u16; 4] = [0, 253, 127, 84];
+/// See datasheet 2.10.6 for more details
+pub const AMBIENT_ANALOGUE_GAIN_CODE: [u8; 8] = [0x46, 0x45, 0x44, 0x43, 0x42, 0x41, 0x40, 0x47];
+pub const AMBIENT_ANALOGUE_GAIN_VALUE: [f32; 8] = [1.01, 1.28, 1.72, 2.60, 5.21, 10.32, 20.0, 40.0];

--- a/src/register/register_tests.rs
+++ b/src/register/register_tests.rs
@@ -1,0 +1,99 @@
+use super::*;
+
+#[test]
+fn interupt_has_error() {
+    assert_eq!(
+        ResultInterruptStatusGpioCode::has_status(
+            ResultInterruptStatusGpioCode::NoError,
+            0b11_000_010
+        ),
+        false
+    )
+}
+#[test]
+fn interupt_has_no_error() {
+    assert_eq!(
+        ResultInterruptStatusGpioCode::has_status(
+            ResultInterruptStatusGpioCode::NoError,
+            0b00_001_001
+        ),
+        true
+    )
+}
+
+#[test]
+fn interupt_has_no_ambient_event() {
+    assert_eq!(
+        ResultInterruptStatusGpioCode::has_status(
+            ResultInterruptStatusGpioCode::NoAmbientEvents,
+            0b00_000_001
+        ),
+        true
+    )
+}
+#[test]
+fn interupt_has_ambient_event() {
+    assert_eq!(
+        ResultInterruptStatusGpioCode::has_status(
+            ResultInterruptStatusGpioCode::NoAmbientEvents,
+            0b00_001_001
+        ),
+        false
+    )
+}
+
+#[test]
+fn interupt_has_no_range_event() {
+    assert_eq!(
+        ResultInterruptStatusGpioCode::has_status(
+            ResultInterruptStatusGpioCode::NoRangeEvents,
+            0b00_000_000
+        ),
+        true
+    )
+}
+#[test]
+fn interupt_has_range_event() {
+    assert_eq!(
+        ResultInterruptStatusGpioCode::has_status(
+            ResultInterruptStatusGpioCode::NoRangeEvents,
+            0b00_000_010
+        ),
+        false
+    )
+}
+
+#[test]
+fn interupt_has_ambient_high_event() {
+    assert_eq!(
+        ResultInterruptStatusGpioCode::has_status(
+            ResultInterruptStatusGpioCode::LevelHighAmbientEvent,
+            0b00_010_111
+        ),
+        true
+    )
+}
+
+#[test]
+fn interupt_has_ambient_low_event() {
+    assert_eq!(
+        ResultInterruptStatusGpioCode::has_status(
+            ResultInterruptStatusGpioCode::LevelLowAmbientEvent,
+            0b10_001_111
+        ),
+        true
+    )
+}
+
+#[test]
+fn range_status_error_code_known() {
+    assert_eq!(
+        RangeStatusErrorCode::try_from(0b0110_0000).unwrap(),
+        RangeStatusErrorCode::EarlyConvergenceEstimate
+    )
+}
+
+#[test]
+fn range_status_error_code_unknown() {
+    assert!(RangeStatusErrorCode::try_from(0b1001_0000).is_err())
+}

--- a/src/start_stop_measurements.rs
+++ b/src/start_stop_measurements.rs
@@ -1,0 +1,97 @@
+use crate::{
+    error::Error,
+    register::{InterleavedModeEnableCode, Register8Bit, SysAmbientStartCode, SysRangeStartCode},
+    VL6180X,
+};
+use embedded_hal::blocking::i2c::{Write, WriteRead};
+
+impl<MODE, I2C, E> VL6180X<MODE, I2C>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+{
+    pub(crate) fn poll_range_mm_single_blocking_direct(&mut self) -> Result<u16, Error<E>> {
+        self.write_named_register(
+            Register8Bit::SYSRANGE__START,
+            SysRangeStartCode::SingleStart as u8,
+        )?;
+        self.read_range_mm_blocking_direct()
+    }
+
+    pub(crate) fn poll_ambient_lux_single_blocking_direct(&mut self) -> Result<f32, Error<E>> {
+        self.write_named_register(
+            Register8Bit::SYSALS__START,
+            SysAmbientStartCode::SingleStart as u8,
+        )?;
+        self.read_ambient_lux_blocking_direct()
+    }
+
+    pub(crate) fn start_ambient_single_direct(&mut self) -> Result<(), E> {
+        self.write_named_register(
+            Register8Bit::SYSALS__START,
+            SysAmbientStartCode::SingleStart as u8,
+        )
+    }
+
+    pub(crate) fn start_range_single_direct(&mut self) -> Result<(), E> {
+        self.write_named_register(
+            Register8Bit::SYSRANGE__START,
+            SysRangeStartCode::SingleStart as u8,
+        )
+    }
+
+    pub(crate) fn toggle_range_continuous_direct(&mut self) -> Result<(), E> {
+        self.write_named_register(
+            Register8Bit::SYSRANGE__START,
+            SysRangeStartCode::ContinuousStartOrStop as u8,
+        )
+    }
+
+    pub(crate) fn toggle_ambient_continuous_direct(&mut self) -> Result<(), E> {
+        self.write_named_register(
+            Register8Bit::SYSALS__START,
+            SysAmbientStartCode::ContinuousStartOrStop as u8,
+        )
+    }
+
+    /// Enables continuous interleaved measurement.
+    pub(crate) fn enable_interleaved_continuous_direct(&mut self) -> Result<(), Error<E>> {
+        self.check_config_valid()?;
+
+        self.write_named_register(
+            Register8Bit::INTERLEAVED_MODE__ENABLE,
+            InterleavedModeEnableCode::Enable as u8,
+        )?;
+        self.write_named_register(
+            Register8Bit::SYSALS__START,
+            SysAmbientStartCode::ContinuousStartOrStop as u8,
+        )?;
+        Ok(())
+    }
+
+    /// For interleaved mode, the following equation must be satisfied:
+    ///
+    /// ([range_max_convergence_time](Config::set_range_max_convergence_time) + 5) +
+    /// ([ambient_integration_period](Config::set_ambient_integration_period) * 1.1)
+    /// ≤ `ambient_inter_measurement_period` * 0.9
+    ///
+    /// The interleaved requirement is only checked when the interleaved mode is started.
+    fn check_config_valid(&self) -> Result<(), Error<E>> {
+        let min_eq_val = (((self.config.range_max_convergence_time + 5) as f32
+            + self.config.ambient_integration_period as f32 * 1.1)
+            / 0.9) as u16;
+        if self.config.ambient_inter_measurement_period < min_eq_val {
+            return Err(Error::InvalidConfigurationValue(
+                self.config.ambient_inter_measurement_period,
+            ));
+        }
+        Ok(())
+    }
+
+    /// Stops interleaved continuous mode.
+    pub fn stop_interleaved_continuous_direct(&mut self) -> Result<(), E> {
+        self.write_named_register(
+            Register8Bit::INTERLEAVED_MODE__ENABLE,
+            InterleavedModeEnableCode::Disable as u8,
+        )
+    }
+}


### PR DESCRIPTION
Initial implementation with the following features:
  - create new driver interface with default config
  - create new driver interface with config
  - poll ambient lux single blocking
  - poll range mm single blocking
  - read ambient
  - read ambient blocking
  - read ambient lux
  - read interrupt status
  - read model id
  - read range mm
  - read range mm blocking
  - start ambient single
  - start range single
  - start ambient continuous mode
  - start interleaved continuous mode
  - start range continuous mode
  - stop ambient continuous mode
  - stop interleaved continuous mode
  - stop range continuous mode
  - change i2c address
  - clear all interrupts
  - clear ambient interrupt
  - clear error interrupt
  - clear range interrupt
  - type state pattern to prevent invalid method calls
  - dynamic mode to allow for more flexible use of the driver
