### PR TITLE
[enh] ported to v1.0.0 of embedded-hal

### DIFF
--- a/.github/workflows/vl6180x-ci.yml
+++ b/.github/workflows/vl6180x-ci.yml
@@ -4,14 +4,14 @@ name: vl6180x-ci
 on:
   push:
     branches:
-      - '**'
+      - "**"
     tags:
       - "*.*.*"
   schedule:
     - cron: 0 0 * * 0
 
 env:
-  RUSTFLAGS: '--deny warnings'
+  RUSTFLAGS: "--deny warnings"
 
 jobs:
   build:
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta, nightly, 1.52.1, 1.49.0]
+        rust: [stable, beta, nightly, 1.70.0]
         TARGET:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
@@ -47,9 +47,9 @@ jobs:
       - name: Checkout CI scripts
         uses: actions/checkout@v2
         with:
-          repository: 'eldruin/rust-driver-ci-scripts'
-          ref: 'master'
-          path: 'ci'
+          repository: "eldruin/rust-driver-ci-scripts"
+          ref: "master"
+          path: "ci"
 
       - run: ./ci/patch-no-std.sh
         if: ${{ ! contains(matrix.TARGET, 'x86_64') }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,18 +2,21 @@
 name = "vl6180x"
 version = "0.2.0"
 description = "A rust driver for the VL6180X (Time-of-Flight I2C laser-ranging module)"
-authors = ["Luca Zulian <lucagiuggia@gmail.com>", "Shao Yuan <flossy_lineage.0b@icloud.com>"]
+authors = [
+    "Luca Zulian <lucagiuggia@gmail.com>",
+    "Shao Yuan <flossy_lineage.0b@icloud.com>",
+]
 categories = ["embedded", "hardware-support", "no-std"]
-keywords = ["hal", "IO",  "embedded-hal-driver", "vl6180x", "tof"]
+keywords = ["hal", "IO", "embedded-hal-driver", "vl6180x", "tof"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/lucazulian/vl6180x"
 edition = "2018"
-exclude = [ "doc", "*.jpg", "*.png", "*.bmp" ]
+exclude = ["doc", "*.jpg", "*.png", "*.bmp"]
 
 [dependencies]
-embedded-hal = {version = "0.2.7", features = ["unproven"]}
-int-enum = {version = "0.4.0", default-features = false}
+embedded-hal = "1.0.0"
+int-enum = { version = "1.1.2", default-features = false }
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vl6180x"
-version = "0.2.0"
+version = "1.0.0"
 description = "A rust driver for the VL6180X (Time-of-Flight I2C laser-ranging module)"
 authors = [
     "Luca Zulian <lucagiuggia@gmail.com>",

--- a/src/config/config_tests.rs
+++ b/src/config/config_tests.rs
@@ -29,4 +29,3 @@ fn set_range_max_convergence_time_value_valid() {
     let mut config = Config::new();
     assert_eq!(config.set_range_max_convergence_time(20), Ok(()))
 }
-

--- a/src/device_status.rs
+++ b/src/device_status.rs
@@ -3,14 +3,11 @@ use crate::{
     error::{Error, Error2},
     register::{Register8Bit::*, SysInterruptClearCode},
 };
-use embedded_hal::{
-    blocking::i2c::{Write, WriteRead},
-    digital::v2::OutputPin,
-};
+use embedded_hal::{digital::OutputPin, i2c::I2c};
 
 impl<MODE, I2C, E> VL6180X<MODE, I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     pub(crate) fn read_model_id_direct(&mut self) -> Result<u8, Error<E>> {
         let id = self.read_named_register(IDENTIFICATION__MODEL_ID)?;

--- a/src/i2c_interface.rs
+++ b/src/i2c_interface.rs
@@ -3,7 +3,7 @@ use crate::register::{Register16Bit, Register8Bit};
 
 impl<MODE, I2C, E> VL6180X<MODE, I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     /// Reads a named 8-bit register
     pub(crate) fn read_named_register(&mut self, reg: Register8Bit) -> Result<u8, E> {

--- a/src/init.rs
+++ b/src/init.rs
@@ -3,11 +3,11 @@ use crate::register::{
     Register16Bit::*, Register8Bit::*, SysModeGpio1Polarity, SysModeGpio1Select,
     AMBIENT_ANALOGUE_GAIN_CODE, RANGE_SCALAR_CODE,
 };
-use embedded_hal::blocking::i2c::{Write, WriteRead};
+use embedded_hal::i2c::I2c;
 
 impl<MODE, I2C, E> VL6180X<MODE, I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     /// Initialize sensor with settings from ST application note AN4545,
     /// section "SR03 settings" - "Mandatory : private registers"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!             .set_open_drain();
 //!         let i2c = dp.I2C1.i2c((scl, sda), 400.kHz(), &clocks);
 //!
-//!         //! To create sensor with default configuration:
+//!         // To create sensor with default configuration:
 //!         let mut tof = vl6180x::VL6180X::new(i2c).expect("vl");
 //!
 //!         loop {
@@ -74,8 +74,8 @@
 #![allow(dead_code)]
 pub use crate::register::ResultInterruptStatusGpioCode;
 pub use config::*;
-use embedded_hal::blocking::i2c::{Write, WriteRead};
-use embedded_hal::digital::v2::{InputPin, OutputPin};
+use embedded_hal::digital::{InputPin, OutputPin};
+use embedded_hal::i2c::I2c;
 pub use error::Error;
 pub use mode::*;
 mod config;
@@ -90,7 +90,7 @@ mod start_stop_measurements;
 
 /// VL6180 interface
 #[derive(Debug, Clone, Copy)]
-pub struct VL6180X<MODE, I2C: Write + WriteRead> {
+pub struct VL6180X<MODE, I2C: I2c> {
     mode: MODE,
     com: I2C,
     config: Config,
@@ -98,7 +98,7 @@ pub struct VL6180X<MODE, I2C: Write + WriteRead> {
 
 /// Convenience container for VL6180, x_shutdown_pin and interrupt_pin
 #[derive(Debug, Clone, Copy)]
-pub struct VL6180XwPins<MODE, I2C: Write + WriteRead, OP: OutputPin, IP: InputPin> {
+pub struct VL6180XwPins<MODE, I2C: I2c, OP: OutputPin, IP: InputPin> {
     /// VL6180
     pub vl6180x: VL6180X<MODE, I2C>,
     /// X Shutdown Pin, output high => powered on, output low => powered off.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! for more examples please see [vl6180x_stm32f401_examples](https://github.com/shaoyuancc/vl6180x_stm32f401_examples)
 //!
-//! ```rust
+//! ```ignore
 //! #![no_std]
 //! #![no_main]
 //!

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -5,8 +5,8 @@ mod ready;
 
 pub use continuous::*;
 pub use dynamic::*;
-use embedded_hal::blocking::i2c::{Write, WriteRead};
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::digital::OutputPin;
+use embedded_hal::i2c::I2c;
 pub use powered_off::*;
 pub use ready::*;
 
@@ -15,7 +15,7 @@ use crate::VL6180X;
 
 impl<MODE, I2C, E> VL6180X<MODE, I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     fn into_mode<MODE2>(self, mode: MODE2) -> VL6180X<MODE2, I2C> {
         VL6180X {
@@ -42,7 +42,7 @@ pub trait AllowStartRangeSingle {}
 
 impl<MODE, I2C, E> VL6180X<MODE, I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
     MODE: AllowReadMeasurement,
 {
     /// Blocking read of the range mesurement.
@@ -87,7 +87,7 @@ where
 
 impl<MODE, I2C, E> VL6180X<MODE, I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
     MODE: AllowStartAmbientSingle,
 {
     /// Trigger ambient light measurement in a non-blocking way.
@@ -108,7 +108,7 @@ where
 
 impl<MODE, I2C, E> VL6180X<MODE, I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
     MODE: AllowStartRangeSingle,
 {
     /// Trigger range mesurement in a non-blocking way.
@@ -127,7 +127,7 @@ where
 
 impl<MODE, I2C, E> VL6180X<MODE, I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
     MODE: AllowCommunication,
 {
     /// Read the model id of the sensor. Should return 0xB4.

--- a/src/mode/continuous.rs
+++ b/src/mode/continuous.rs
@@ -1,5 +1,5 @@
 use crate::{error::Error, AllowCommunication, VL6180X};
-use embedded_hal::blocking::i2c::{Write, WriteRead};
+use embedded_hal::i2c::I2c;
 
 use super::{AllowReadMeasurement, AllowStartAmbientSingle, AllowStartRangeSingle, ReadyMode};
 
@@ -15,7 +15,7 @@ impl AllowCommunication for RangeContinuousMode {}
 
 impl<I2C, E> VL6180X<RangeContinuousMode, I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     /// Stops range continuous mode.
     pub fn stop_range_continuous_mode(mut self) -> Result<VL6180X<ReadyMode, I2C>, Error<E>> {
@@ -36,7 +36,7 @@ impl AllowCommunication for AmbientContinuousMode {}
 
 impl<I2C, E> VL6180X<AmbientContinuousMode, I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     /// Stops ambient continuous mode.
     pub fn stop_ambient_continuous_mode(mut self) -> Result<VL6180X<ReadyMode, I2C>, Error<E>> {
@@ -58,7 +58,7 @@ impl AllowCommunication for InterleavedContinuousMode {}
 
 impl<I2C, E> VL6180X<InterleavedContinuousMode, I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     /// Stops interleaved continuous mode.
     pub fn stop_interleaved_continuous_mode(mut self) -> Result<VL6180X<ReadyMode, I2C>, Error<E>> {

--- a/src/mode/dynamic.rs
+++ b/src/mode/dynamic.rs
@@ -1,9 +1,6 @@
 use crate::error::{Error, Error2};
 use crate::VL6180X;
-use embedded_hal::{
-    blocking::i2c::{Write, WriteRead},
-    digital::v2::OutputPin,
-};
+use embedded_hal::{digital::OutputPin, i2c::I2c};
 use OperatingMode::*;
 
 /// A mode where the state is kept track of at runtime, instead of being
@@ -41,7 +38,7 @@ impl DynamicMode {
 
 impl<I2C, E> VL6180X<DynamicMode, I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     /// Same functionality as [`poll_range_mm_single_blocking()`](VL6180X::poll_range_mm_single_blocking)
     /// but with a check on the current [OperatingMode].

--- a/src/mode/powered_off.rs
+++ b/src/mode/powered_off.rs
@@ -1,7 +1,4 @@
-use embedded_hal::{
-    blocking::i2c::{Write, WriteRead},
-    digital::v2::OutputPin,
-};
+use embedded_hal::{digital::OutputPin, i2c::I2c};
 
 use crate::{error::Error2, mode::ReadyMode, VL6180X};
 
@@ -11,7 +8,7 @@ pub struct PoweredOffMode {}
 
 impl<I2C, E> VL6180X<PoweredOffMode, I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     /// Powers on the sensor by setting the `x_shutdown_pin` high.
     /// It then busy waits for the device to be booted and initializes the device.

--- a/src/mode/ready.rs
+++ b/src/mode/ready.rs
@@ -1,6 +1,6 @@
 use crate::{error::Error, Config};
 use crate::{AllowCommunication, VL6180X};
-use embedded_hal::blocking::i2c::{Write, WriteRead};
+use embedded_hal::i2c::I2c;
 
 use super::{
     AllowReadMeasurement, AllowStartAmbientSingle, AllowStartRangeSingle, AmbientContinuousMode,
@@ -21,7 +21,7 @@ impl AllowStartAmbientSingle for ReadyMode {}
 
 impl<I2C, E> VL6180X<ReadyMode, I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     /// Create a new VL6180X driver
     pub fn new(i2c: I2C) -> Result<Self, Error<E>> {

--- a/src/read_measurements.rs
+++ b/src/read_measurements.rs
@@ -8,11 +8,11 @@ use crate::{
     },
     VL6180X,
 };
-use embedded_hal::blocking::i2c::{Write, WriteRead};
+use embedded_hal::i2c::I2c;
 
 impl<MODE, I2C, E> VL6180X<MODE, I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     pub(crate) fn read_range_mm_blocking_direct(&mut self) -> Result<u16, Error<E>> {
         let mut c = 0;
@@ -42,7 +42,7 @@ where
     }
 
     fn get_range_val_and_status(&mut self) -> Result<u16, Error<E>> {
-        let status = self.read_named_register(Register8Bit::RESULT__RANGE_STATUS)?;
+        let status = self.read_named_register(Register8Bit::RESULT__RANGE_STATUS)? >> 4;
         self.clear_range_interrupt_direct()?;
         let error = RangeStatusErrorCode::try_from(status)
             .map_err(|_| Error::UnknownRegisterCode(status))?;
@@ -108,7 +108,7 @@ where
     }
 
     fn get_ambient_val_and_status(&mut self) -> Result<u16, Error<E>> {
-        let status = self.read_named_register(Register8Bit::RESULT__ALS_STATUS)?;
+        let status = self.read_named_register(Register8Bit::RESULT__ALS_STATUS)? >> 4;
         self.clear_ambient_interrupt_direct()?;
         let error = AmbientStatusErrorCode::try_from(status)
             .map_err(|_| Error::UnknownRegisterCode(status))?;

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,5 +1,4 @@
-use core::convert::TryFrom;
-use int_enum::{IntEnum, IntEnumError};
+use int_enum::IntEnum;
 
 #[cfg(test)]
 mod register_tests;
@@ -246,13 +245,6 @@ impl RangeStatusErrorCode {
     }
 }
 
-impl TryFrom<u8> for RangeStatusErrorCode {
-    type Error = IntEnumError<Self>;
-    fn try_from(code: u8) -> Result<Self, Self::Error> {
-        RangeStatusErrorCode::from_int(code >> 4)
-    }
-}
-
 /// Errors from performing an ambient light measurement
 /// See VL6180X datasheet section 6.2.38 RESULT__ALS_STATUS
 // Bits 7:4 of what is returned from the register
@@ -273,12 +265,6 @@ impl AmbientStatusErrorCode {
     }
 }
 
-impl TryFrom<u8> for AmbientStatusErrorCode {
-    type Error = IntEnumError<Self>;
-    fn try_from(code: u8) -> Result<Self, Self::Error> {
-        AmbientStatusErrorCode::from_int(code >> 4)
-    }
-}
 // RANGE_SCALER values for 1x, 2x, 3x scaling - see STSW-IMG003 core/src/vl6180x_api.c (ScalerLookUP[])
 pub const RANGE_SCALAR_CODE: [u16; 4] = [0, 253, 127, 84];
 /// See datasheet 2.10.6 for more details

--- a/src/register/register_tests.rs
+++ b/src/register/register_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use core::convert::TryFrom;
 
 #[test]
 fn interupt_has_error() {
@@ -88,12 +89,12 @@ fn interupt_has_ambient_low_event() {
 #[test]
 fn range_status_error_code_known() {
     assert_eq!(
-        RangeStatusErrorCode::try_from(0b0110_0000).unwrap(),
+        RangeStatusErrorCode::try_from(0b0110_0000 >> 4 as u8).unwrap(),
         RangeStatusErrorCode::EarlyConvergenceEstimate
     )
 }
 
 #[test]
 fn range_status_error_code_unknown() {
-    assert!(RangeStatusErrorCode::try_from(0b1001_0000).is_err())
+    assert!(RangeStatusErrorCode::try_from(0b1001_0000 >> 4).is_err())
 }

--- a/src/register/register_tests.rs
+++ b/src/register/register_tests.rs
@@ -11,6 +11,7 @@ fn interupt_has_error() {
         false
     )
 }
+
 #[test]
 fn interupt_has_no_error() {
     assert_eq!(

--- a/src/start_stop_measurements.rs
+++ b/src/start_stop_measurements.rs
@@ -3,11 +3,11 @@ use crate::{
     register::{InterleavedModeEnableCode, Register8Bit, SysAmbientStartCode, SysRangeStartCode},
     VL6180X,
 };
-use embedded_hal::blocking::i2c::{Write, WriteRead};
+use embedded_hal::i2c::I2c;
 
 impl<MODE, I2C, E> VL6180X<MODE, I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     pub(crate) fn poll_range_mm_single_blocking_direct(&mut self) -> Result<u16, Error<E>> {
         self.write_named_register(


### PR DESCRIPTION
Migrated to the new API of `embedded-hal` which [unified some traits](https://github.com/rust-embedded/embedded-hal/blob/master/docs/migrating-from-0.2-to-1.0.md#trait-unification).

Tested on Linux with both `linux_embedded_hal` and `ftdi_embedded_hal`:

```rust
use clap::Parser;
// use ftdi;
// use ftdi_embedded_hal as hal;
use linux_embedded_hal::I2cdev;
use vl6180x;

use std::{thread, time};

/// Simple vl6180x scanner
#[derive(Parser, Debug)]
#[command(version, about, long_about = None)]
struct Args {
    /// Bus number (/dev/i2c<x>)
    #[arg()]
    bus: u8,
}

fn main() {
    let args = Args::parse();
    let mut i2c = I2cdev::new(format!("/dev/i2c-{}", args.bus)).unwrap();

    // let device = ftdi::find_by_vid_pid(0x0403, 0x6011)
    //     .interface(ftdi::Interface::B)
    //     .open()
    //     .unwrap();
    // let hal = hal::FtHal::init_freq(device, 100_000).unwrap();
    // let mut i2c = hal.i2c().unwrap();

    let mut tof = vl6180x::VL6180X::new(&mut i2c).expect("vl");
    loop {
        thread::sleep(time::Duration::from_micros(500));
        match tof.poll_range_mm_single_blocking() {
            Ok(range) => println!("Range Single Poll: {}mm", range),
            Err(e) => println!("Error reading TOF sensor Single Poll! {:?}", e),
        }
    }
}
```

Cargo.toml:
```toml
[package]
name = "vl6180x-test"
version = "0.1.0"
edition = "2021"

[dependencies]
clap = { version = "4.5.21", features = ["derive"] }
embedded-hal = "1.0.0"
# ftdi = "0.1.3"
# libftd2xx = "0.33.1"
# ftdi-embedded-hal = { version = "0.9.1", features = ["libftd2xx"] }
linux-embedded-hal = "0.4.0"
vl6180x = { path = "../vl6180x" }

```